### PR TITLE
Namespace support

### DIFF
--- a/src/main/java/org/primeframework/mvc/action/annotation/Action.java
+++ b/src/main/java/org/primeframework/mvc/action/annotation/Action.java
@@ -44,6 +44,13 @@ public @interface Action {
   boolean jwtEnabled() default false;
 
   /**
+   * An optional namespace for this action. Similar to the prefixParameter, but this must be at the front of the URI.
+   *
+   * @return the namespace parameters.
+   */
+  String namespace() default "";
+
+  /**
    * Determines if the action can be overridden by another action that maps to the same URI. If a class that is marked
    * as overridable and another another class is found for the same URI but is not marked as overridable, that one is
    * used.

--- a/src/test/java/org/example/action/wellKnown/OpenidConfigurationAction.java
+++ b/src/test/java/org/example/action/wellKnown/OpenidConfigurationAction.java
@@ -25,14 +25,18 @@ import org.primeframework.mvc.content.json.annotation.JSONResponse;
 /**
  * @author Daniel DeGroff
  */
-@Action
+@Action(namespace = "{tenantId}")
 @JSON
 public class OpenidConfigurationAction {
   @JSONResponse
   public Map<String, String> response = new HashMap<>();
 
+  public String tenantId;
+
   public String get() {
-    response.put("called", "/.well-known/openid-configuration");
+    response.put("called", tenantId == null
+        ? "/.well-known/openid-configuration"
+        : "/" + tenantId + "/.well-known/openid-configuration");
     return "success";
   }
 }

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -990,11 +990,12 @@ public class GlobalTest extends PrimeBaseTest {
                                  .assertHeaderContains("Cache-Control", "no-cache")
                                  .assertJSON("{\"called\": \"/.well-known/well-known/potato/openid-configuration\"}"));
 
-    test.simulate(() -> simulator.test("/.well-known/.well-known/openid-configuration")
+    // Use a namespace
+    test.simulate(() -> simulator.test("/a070429c-dab2-464f-9d53-2cad82b615c7/.well-known/openid-configuration")
                                  .get()
-                                 .assertStatusCode(500)
-                                 // A 500 will not contain these headers
-                                 .assertHeaderDoesNotContain("Cache-Control"));
+                                 .assertStatusCode(200)
+                                 .assertHeaderContains("Cache-Control", "no-cache")
+                                 .assertJSON("{\"called\": \"/a070429c-dab2-464f-9d53-2cad82b615c7/.well-known/openid-configuration\"}"));
   }
 
   @Test


### PR DESCRIPTION
Initial support for namespace so we can support "tenant" things. Such as `/{tenantId}/.well-known/openid-configuration`. 

Currently if you define a `namespace` on the `@Action` it is optional. I could see it working both ways, but since it is just a parameter in the end, it feels like it should be up to the action to validate and say "missing tenantId" (for example) instead of throwing a `404`. But this could also be configurable. 