### PR TITLE
Having base json content handler replace request input stream after d…

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.3"
 testngVersion = "7.6.1"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.0.12", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.0.13", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
@@ -15,6 +15,7 @@
  */
 package org.primeframework.mvc.content.json;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -109,6 +110,9 @@ public abstract class BaseJacksonContentHandler implements ContentHandler {
         if (logger.isDebugEnabled()) {
           String body = new String(request.getBodyBytes(), 0, contentLength.intValue());
           logger.debug("Request: ({} {}) {}", request.getMethod(), request.getPath(), body);
+
+          // Replace the input stream, in case anything downstream wants to use it
+          request.setInputStream(new ByteArrayInputStream(body.getBytes(request.getCharacterEncoding())));
         }
 
         // Retrieve the current value from the action, so we can see if it is non-null

--- a/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
@@ -112,7 +112,9 @@ public abstract class BaseJacksonContentHandler implements ContentHandler {
           logger.debug("Request: ({} {}) {}", request.getMethod(), request.getPath(), body);
 
           // Replace the input stream, in case anything downstream wants to use it
-          request.setInputStream(new ByteArrayInputStream(body.getBytes(request.getCharacterEncoding())));
+          if(request.getInputStream() != null) {
+            request.setInputStream(new ByteArrayInputStream(body.getBytes(request.getCharacterEncoding())));
+          }
         }
 
         // Retrieve the current value from the action, so we can see if it is non-null


### PR DESCRIPTION
…epleting it

# Issue
BaseJacksonContentHandler has a block that executes if debug logging is turned on. In this block, the request's input stream is read and logged, which invalidates the input stream for downstream code using the request.

# Solution
After reading the inputstream into a string, replace it with an inputstream created on the string for those downstream users. 