### PR TITLE
NoBody is allowed to CORS without a Content-Type

### DIFF
--- a/src/main/java/org/primeframework/mvc/cors/CORSFilter.java
+++ b/src/main/java/org/primeframework/mvc/cors/CORSFilter.java
@@ -280,10 +280,10 @@ public final class CORSFilter {
       } else if (HTTPMethod.GET.is(method) || HTTPMethod.HEAD.is(method)) {
         requestType = CORSRequestType.SIMPLE;
       } else if (HTTPMethod.POST.is(method)) {
+        Long contentLength = request.getContentLength();
         String contentType = request.getContentType();
-        if (contentType != null) {
-          contentType = contentType.toLowerCase().trim();
-          if (SimpleHTTPRequestContentTypes.contains(contentType)) {
+        if (contentType != null || 0 == contentLength) {
+          if (contentType != null && SimpleHTTPRequestContentTypes.contains(contentType.toLowerCase().trim())) {
             requestType = CORSRequestType.SIMPLE;
           } else {
             requestType = CORSRequestType.ACTUAL;


### PR DESCRIPTION
We were always checking content-type but some browsers (Chrome) will withhold the content-type header if the POST request has no body. These should be valid requests that actually don't have content so if the content-length is 0 we should not check that header