### PR TITLE
More debug on duplicate parameters.

### DIFF
--- a/src/main/java/org/primeframework/mvc/parameter/DefaultParameterHandler.java
+++ b/src/main/java/org/primeframework/mvc/parameter/DefaultParameterHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2020, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.primeframework.mvc.message.l10n.MissingMessageException;
 import org.primeframework.mvc.parameter.ParameterParser.Parameters;
 import org.primeframework.mvc.parameter.ParameterParser.Parameters.Struct;
 import org.primeframework.mvc.parameter.convert.ConversionException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.el.BeanExpressionException;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 import org.primeframework.mvc.parameter.el.ExpressionException;
@@ -52,8 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is the default parameter handler. It sets all of the parameters into the action in the following order
- * (while invoking the correct methods in the order):
+ * This class is the default parameter handler. It sets all the parameters into the action in the following order (while invoking the correct methods
+ * in the order):
  * <p>
  * <ol>
  * <li>Set pre-parameters</li>
@@ -204,8 +205,7 @@ public class DefaultParameterHandler implements ParameterHandler {
    *
    * @param values                 The value mapping.
    * @param actionInvocation       The action invocation.
-   * @param allowUnknownParameters Whether or not invalid parameters should throw an exception or just be ignored and
-   *                               log a fine message.
+   * @param allowUnknownParameters Whether invalid parameters should throw an exception or just be ignored and log a fine message.
    */
   protected void setValues(Map<String, Struct> values, ActionInvocation actionInvocation,
                            boolean allowUnknownParameters) {
@@ -233,6 +233,11 @@ public class DefaultParameterHandler implements ParameterHandler {
         } else {
           throw ee;
         }
+      } catch (MultipleParametersUnsupportedException e) {
+        // Re-throw after adding some meta-data about the current request to make it easier to debug in the log.
+        // - Intentionally not recording the value to avoid logging anything sensitive.
+        throw new MultipleParametersUnsupportedException(e.getMessage() +
+            " Action class [" + action.getClass().getName() + "] Request URI [" + actionInvocation.actionURI + "] Parameter name [" + key + "]");
       }
     }
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/MultipleParametersUnsupportedException.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/MultipleParametersUnsupportedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,31 +13,18 @@
  * either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-package org.example.action;
-
-import java.util.UUID;
-
-import org.primeframework.mvc.action.annotation.Action;
+package org.primeframework.mvc.parameter.convert;
 
 /**
- * Test the order of operation on parameter handling.
+ * This is a runtime exception thrown when a request contains more than one value by name and the object type is not a data type that can accept more
+ * than one value.
+ * <p>
+ * This is either a development time issue, or a bug in a form caused by a duplicate field.
  *
  * @author Daniel DeGroff
  */
-@Action("{value}")
-public class ParameterHandlerAction {
-  public Fruit enumValue;
-
-  public UUID uuidValue;
-
-  public String value;
-
-  public String post() {
-    return "success";
-  }
-
-  public enum Fruit {
-    Orange,
-    Apple
+public class MultipleParametersUnsupportedException extends UnsupportedOperationException {
+  public MultipleParametersUnsupportedException(String message) {
+    super(message);
   }
 }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/EnumConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/EnumConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2007, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.primeframework.mvc.config.MVCConfiguration;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -61,7 +62,7 @@ public class EnumConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type Enum. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/LocalDateConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/LocalDateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.primeframework.mvc.config.MVCConfiguration;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -81,7 +82,7 @@ public class LocalDateConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type LocalDate. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/URIConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/URIConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2018-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -54,7 +55,7 @@ public class URIConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type java.net.URI. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/URLConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/URLConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2013-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -53,7 +54,7 @@ public class URLConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type java.net.URL. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/UUIDConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/UUIDConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2007, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.primeframework.mvc.config.MVCConfiguration;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -71,7 +72,7 @@ public class UUIDConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type UUID. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/ZoneIdConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/ZoneIdConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2018-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -54,7 +55,7 @@ public class ZoneIdConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type java.time.ZoneId. This isn't " +
         "allowed.");
   }

--- a/src/main/java/org/primeframework/mvc/parameter/convert/converters/ZonedDateTimeConverter.java
+++ b/src/main/java/org/primeframework/mvc/parameter/convert/converters/ZonedDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.primeframework.mvc.config.MVCConfiguration;
 import org.primeframework.mvc.parameter.convert.AbstractGlobalConverter;
 import org.primeframework.mvc.parameter.convert.ConversionException;
 import org.primeframework.mvc.parameter.convert.ConverterStateException;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.convert.annotation.GlobalConverter;
 
 /**
@@ -89,7 +90,7 @@ public class ZonedDateTimeConverter extends AbstractGlobalConverter {
 
   protected Object stringsToObject(String[] values, Type convertTo, Map<String, String> attributes, String expression)
       throws ConversionException, ConverterStateException {
-    throw new UnsupportedOperationException("You are attempting to map a form field that contains " +
+    throw new MultipleParametersUnsupportedException("You are attempting to map a form field that contains " +
         "multiple parameters to a property on the action class that is of type DateTime. This isn't " +
         "allowed.");
   }

--- a/src/test/java/org/example/action/ParameterHandlerAction.java
+++ b/src/test/java/org/example/action/ParameterHandlerAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.example.action;
 import java.util.UUID;
 
 import org.primeframework.mvc.action.annotation.Action;
+import org.primeframework.mvc.action.result.annotation.Status;
 
 /**
  * Test the order of operation on parameter handling.
@@ -25,6 +26,7 @@ import org.primeframework.mvc.action.annotation.Action;
  * @author Daniel DeGroff
  */
 @Action("{value}")
+@Status(code = "unhandled", status = 500)
 public class ParameterHandlerAction {
   public Fruit enumValue;
 

--- a/src/test/java/org/example/action/ParameterHandlerAction.java
+++ b/src/test/java/org/example/action/ParameterHandlerAction.java
@@ -26,7 +26,7 @@ import org.primeframework.mvc.action.result.annotation.Status;
  * @author Daniel DeGroff
  */
 @Action("{value}")
-@Status(code = "unhandled", status = 500)
+@Status(code = "error", status = 500)
 public class ParameterHandlerAction {
   public Fruit enumValue;
 

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -52,6 +52,7 @@ import io.fusionauth.http.HTTPValues.Methods;
 import org.example.action.JwtAuthorizedAction;
 import org.example.action.LotsOfMessagesAction;
 import org.example.action.OverrideMeAction;
+import org.example.action.ParameterHandlerAction;
 import org.example.action.store.BaseStoreAction;
 import org.example.action.user.EditAction;
 import org.example.domain.UserField;
@@ -2138,6 +2139,31 @@ public class GlobalTest extends PrimeBaseTest {
         .simulate(() -> simulator.test("/another-extended-scope-storage")
                                  .get())
         .assertContextAttributeNotNull("contextObject");
+  }
+
+  @Test
+  public void post_unsupported_multipleParameters() throws Exception {
+    // Cannot jam an array into a non-array data type
+    // - We don't currently have an easy way to capture the exception in the execute thread.
+
+    // UUID, two values, no dice.
+    // - We will get a 200, watch the console for the log output.
+    test.simulate(() -> simulator.test("/parameter-handler")
+                                 .withParameter("uuidValue", UUID.randomUUID())
+                                 .withParameter("uuidValue", UUID.randomUUID())
+                                 .post()
+                                 .assertContainsNoGeneralErrors()
+                                 .assertStatusCode(200));
+
+
+    // Enum, two values, no dice
+    // - We will get a 200, watch the console for the log output.
+    test.simulate(() -> simulator.test("/parameter-handler")
+                                 .withParameter("enumValue", ParameterHandlerAction.Fruit.Orange)
+                                 .withParameter("enumValue", ParameterHandlerAction.Fruit.Apple)
+                                 .post()
+                                 .assertContainsNoGeneralErrors()
+                                 .assertStatusCode(200));
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -61,6 +61,7 @@ import org.primeframework.mvc.container.ContainerResolver;
 import org.primeframework.mvc.message.MessageType;
 import org.primeframework.mvc.parameter.convert.ConverterProvider;
 import org.primeframework.mvc.parameter.convert.GlobalConverter;
+import org.primeframework.mvc.parameter.convert.MultipleParametersUnsupportedException;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 import org.primeframework.mvc.util.URIBuilder;
 import org.testng.annotations.BeforeClass;
@@ -2144,7 +2145,6 @@ public class GlobalTest extends PrimeBaseTest {
   @Test
   public void post_unsupported_multipleParameters() throws Exception {
     // Cannot jam an array into a non-array data type
-    // - We don't currently have an easy way to capture the exception in the execute thread.
 
     // UUID, two values, no dice.
     // - We will get a 200, watch the console for the log output.
@@ -2152,9 +2152,11 @@ public class GlobalTest extends PrimeBaseTest {
                                  .withParameter("uuidValue", UUID.randomUUID())
                                  .withParameter("uuidValue", UUID.randomUUID())
                                  .post()
-                                 .assertContainsNoGeneralErrors()
-                                 .assertStatusCode(200));
+                                 .assertStatusCode(500)
+                                 .assertBodyIsEmpty());
 
+    TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
+        "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type UUID. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [uuidValue]"));
 
     // Enum, two values, no dice
     // - We will get a 200, watch the console for the log output.
@@ -2162,8 +2164,11 @@ public class GlobalTest extends PrimeBaseTest {
                                  .withParameter("enumValue", ParameterHandlerAction.Fruit.Orange)
                                  .withParameter("enumValue", ParameterHandlerAction.Fruit.Apple)
                                  .post()
-                                 .assertContainsNoGeneralErrors()
-                                 .assertStatusCode(200));
+                                 .assertStatusCode(500)
+                                 .assertBodyIsEmpty());
+
+    TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
+        "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type Enum. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [enumValue]"));
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -526,7 +526,7 @@ public abstract class PrimeBaseTest {
 
     @Override
     public void handle(Exception exception) {
-      resultStore.set("unhandled");
+      resultStore.set("error");
       TestUnhandledExceptionHandler.exception = exception;
     }
   }


### PR DESCRIPTION
FusionAuth has themed pages, which means a client can customize a form. 

If a client adds a duplicate parameter by accident, and the data type is a `UUID`, `Enum` or something other than `String`, we'll fail in the parameter handler workflow. 

This PR adds more info to the error so that an end user could possibly identify the issue from the log, or an engineer can quickly nail down the issue. 