### PR TITLE
Don't require InputStream to be non-null when we are in a HEAD request.

### DIFF
--- a/src/main/java/org/primeframework/mvc/action/result/StreamResult.java
+++ b/src/main/java/org/primeframework/mvc/action/result/StreamResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2019, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,15 +60,9 @@ public class StreamResult extends AbstractResult<Stream> {
     String name = expand(stream.name(), action, false);
     String type = expand(stream.type(), action, false);
 
-    Object object = expressionEvaluator.getValue(property, action);
-    if (!(object instanceof InputStream is)) {
-      throw new PrimeException("Invalid property [" + property + "] for Stream result. This " +
-          "property returned null or an Object that is not an InputStream.");
-    }
-
     ZonedDateTime lastModified = null;
     try {
-      object = expressionEvaluator.getValue(lastModifiedProperty, action);
+      Object object = expressionEvaluator.getValue(lastModifiedProperty, action);
       if (!(object instanceof ZonedDateTime)) {
         throw new PrimeException("Invalid property [" + property + "] for Stream result. This " +
             "property returned null or an Object that is not an InputStream.");
@@ -100,7 +94,20 @@ public class StreamResult extends AbstractResult<Stream> {
       return true;
     }
 
+    Object object = expressionEvaluator.getValue(property, action);
+    if (!(object instanceof InputStream is)) {
+      throw new PrimeException("Invalid property [" + property + "] for Stream result. This " +
+          "property returned null or an Object that is not an InputStream.");
+    }
+
     is.transferTo(response.getOutputStream());
+
+    // We don't know what type of InputStream was provided. We should close it for good measure.
+    try {
+      is.close();
+    } catch (IOException ignore) {
+    }
+
     return true;
   }
 

--- a/src/test/java/org/primeframework/mvc/action/result/StreamResultTest.java
+++ b/src/test/java/org/primeframework/mvc/action/result/StreamResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2019, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,8 +54,9 @@ public class StreamResultTest extends PrimeBaseTest {
     EasyMock.expect(ee.expand("10", action, false)).andReturn("10");
     EasyMock.expect(ee.expand(fileName, action, false)).andReturn(fileName);
     EasyMock.expect(ee.expand("application/octet-stream", action, false)).andReturn("application/octet-stream");
-    EasyMock.expect(ee.getValue("stream", action)).andReturn(new ByteArrayInputStream("test".getBytes()));
     EasyMock.expect(ee.getValue("lastModified", action)).andReturn(lastModified);
+    EasyMock.expect(ee.getValue("stream", action)).andReturn(new ByteArrayInputStream("test".getBytes()));
+
     EasyMock.replay(ee);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
Don't require InputStream to be non-null when we are in a HEAD request.

This allows a user to optionally leave this null and not open a file descriptor when in a HEAD request.

Also, close out the InputStream after we transfer it to the OutputStream. I think this was making the assumption that the caller is using a ByteArrayInputStream (for example) that does not need to be closed.