### PR TITLE
Add aggregate request metrics and bump version

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.3"
 testngVersion = "7.7.1"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.9.14", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.10.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.3"
 testngVersion = "7.7.1"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.9.13", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.9.14", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.9.14</version>
+  <version>4.10.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.9.13</version>
+  <version>4.9.14</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/action/DefaultActionMappingWorkflow.java
+++ b/src/main/java/org/primeframework/mvc/action/DefaultActionMappingWorkflow.java
@@ -111,9 +111,9 @@ public class DefaultActionMappingWorkflow implements ActionMappingWorkflow {
         perPathTimer = metricRegistry.timer("prime-mvc.[" + actionInvocation.uri() + "].requests").time();
 
         //noinspection resource
-        aggregateTimer = metricRegistry.timer("prime-mvc.all.requests").time();
+        aggregateTimer = metricRegistry.timer("prime-mvc.[*].requests").time();
         perPathErrorMeter = metricRegistry.meter("prime-mvc.[" + actionInvocation.uri() + "].errors");
-        aggregateErrorMeter = metricRegistry.meter("prime-mvc.all.errors");
+        aggregateErrorMeter = metricRegistry.meter("prime-mvc.[*].errors");
       }
 
       chain.continueWorkflow();

--- a/src/main/java/org/primeframework/mvc/action/DefaultActionMappingWorkflow.java
+++ b/src/main/java/org/primeframework/mvc/action/DefaultActionMappingWorkflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This class is the default implementation of the ActionMappingWorkflow. During the perform method, this class
- * determines the action that will be invoked based on the URI and put it into the ActionInvocationStore.
+ * This class is the default implementation of the ActionMappingWorkflow. During the perform method, this class determines the action that will be
+ * invoked based on the URI and put it into the ActionInvocationStore.
  *
  * @author Brian Pontarelli
  */
@@ -54,8 +54,8 @@ public class DefaultActionMappingWorkflow implements ActionMappingWorkflow {
   @Inject(optional = true) private MetricRegistry metricRegistry;
 
   @Inject
-  public DefaultActionMappingWorkflow(HTTPRequest request, HTTPResponse response,
-                                      ActionInvocationStore actionInvocationStore, ActionMapper actionMapper) {
+  public DefaultActionMappingWorkflow(HTTPRequest request, HTTPResponse response, ActionInvocationStore actionInvocationStore,
+                                      ActionMapper actionMapper) {
     this.request = request;
     this.response = response;
     this.actionInvocationStore = actionInvocationStore;
@@ -63,8 +63,7 @@ public class DefaultActionMappingWorkflow implements ActionMappingWorkflow {
   }
 
   /**
-   * Processes the request URI, loads the action configuration, creates the action and stores the invocation in the
-   * request.
+   * Processes the request URI, loads the action configuration, creates the action and stores the invocation in the request.
    *
    * @param chain The workflow chain.
    * @throws IOException If the chain throws an exception.
@@ -98,16 +97,23 @@ public class DefaultActionMappingWorkflow implements ActionMappingWorkflow {
       throw new NotAllowedException();
     }
 
-    // Start the timer and grab a meter for errors
-    Timer.Context timer = null;
-    Meter errorMeter = null;
+    // Start the timers and grab some meters for errors
+    Timer.Context perPathTimer = null;
+    Timer.Context aggregateTimer = null;
+    Meter perPathErrorMeter = null;
+    Meter aggregateErrorMeter = null;
 
     try {
       if (metricRegistry != null && actionInvocation.action != null) {
         // Ignore try/resource inspection, we are closing this in the finally block already
+
         //noinspection resource
-        timer = metricRegistry.timer("prime-mvc.[" + actionInvocation.uri() + "].requests").time();
-        errorMeter = metricRegistry.meter("prime-mvc.[" + actionInvocation.uri() + "].errors");
+        perPathTimer = metricRegistry.timer("prime-mvc.[" + actionInvocation.uri() + "].requests").time();
+
+        //noinspection resource
+        aggregateTimer = metricRegistry.timer("prime-mvc.all.requests").time();
+        perPathErrorMeter = metricRegistry.meter("prime-mvc.[" + actionInvocation.uri() + "].errors");
+        aggregateErrorMeter = metricRegistry.meter("prime-mvc.all.errors");
       }
 
       chain.continueWorkflow();
@@ -115,14 +121,22 @@ public class DefaultActionMappingWorkflow implements ActionMappingWorkflow {
       // We need to leave the action in the store because it might be used by the Error Workflow
       actionInvocationStore.removeCurrent();
     } catch (IOException | RuntimeException | Error e) {
-      if (errorMeter != null) {
-        errorMeter.mark();
+      if (perPathErrorMeter != null) {
+        perPathErrorMeter.mark();
+      }
+
+      if (aggregateErrorMeter != null) {
+        aggregateErrorMeter.mark();
       }
 
       throw e;
     } finally {
-      if (timer != null) {
-        timer.stop();
+      if (aggregateTimer != null) {
+        aggregateTimer.stop();
+      }
+
+      if (perPathTimer != null) {
+        perPathTimer.stop();
       }
     }
   }

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -731,6 +731,7 @@ public class GlobalTest extends PrimeBaseTest {
 
     Map<String, Timer> timers = metricRegistry.getTimers();
     assertEquals(timers.get("prime-mvc.[/user/full-form].requests").getCount(), 1);
+    assertEquals(timers.get("prime-mvc.all.requests").getCount(), 1);
   }
 
   @Test
@@ -744,6 +745,7 @@ public class GlobalTest extends PrimeBaseTest {
 
     Map<String, Meter> meters = metricRegistry.getMeters();
     assertEquals(meters.get("prime-mvc.[/execute-method-throws-exception].errors").getCount(), 1);
+    assertEquals(meters.get("prime-mvc.all.errors").getCount(), 1);
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -731,7 +731,7 @@ public class GlobalTest extends PrimeBaseTest {
 
     Map<String, Timer> timers = metricRegistry.getTimers();
     assertEquals(timers.get("prime-mvc.[/user/full-form].requests").getCount(), 1);
-    assertEquals(timers.get("prime-mvc.all.requests").getCount(), 1);
+    assertEquals(timers.get("prime-mvc.[*].requests").getCount(), 1);
   }
 
   @Test
@@ -745,7 +745,7 @@ public class GlobalTest extends PrimeBaseTest {
 
     Map<String, Meter> meters = metricRegistry.getMeters();
     assertEquals(meters.get("prime-mvc.[/execute-method-throws-exception].errors").getCount(), 1);
-    assertEquals(meters.get("prime-mvc.all.errors").getCount(), 1);
+    assertEquals(meters.get("prime-mvc.[*].errors").getCount(), 1);
   }
 
   @Test


### PR DESCRIPTION
Adds aggregate HTTP metrics.

**Issue:**
- https://github.com/FusionAuth/fusionauth-internal-issues/issues/281

Capture of new prometheus output:
```
# HELP prime_mvc_all_errors_total Generated from Dropwizard metric import (metric=prime-mvc.all.errors, type=com.codahale.metrics.Meter)
# TYPE prime_mvc_all_errors_total counter
prime_mvc_all_errors_total 5.0
# HELP prime_mvc_all_requests Generated from Dropwizard metric import (metric=prime-mvc.all.requests, type=com.codahale.metrics.Timer)
# TYPE prime_mvc_all_requests summary
prime_mvc_all_requests{quantile="0.5",} 0.018341042000000002
prime_mvc_all_requests{quantile="0.75",} 0.022982875
prime_mvc_all_requests{quantile="0.95",} 0.026575375000000002
prime_mvc_all_requests{quantile="0.98",} 0.030771000000000003
prime_mvc_all_requests{quantile="0.99",} 0.047524667
prime_mvc_all_requests{quantile="0.999",} 0.09823404200000001
prime_mvc_all_requests_count 358.0
```