### PR TITLE
Add static resource filters to allow each request to optionally reject based upon the URI

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -19,7 +19,7 @@ dropWizardVersion = "3.2.6"
 easyMockVersion = "5.1.0"
 freemarkerVersion = "2.3.32"
 fusionAuthJWTVersion = "5.1.0"
-javaHTTPVersion = "0.2.7"
+javaHTTPVersion = "0.2.8"
 jsonPatchVersion = "1.13.0"
 guavaVersion = "32.1.2-jre"
 guiceVersion = "6.0.0"
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.16.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.17.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.16.0</version>
+  <version>4.17.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>java-http</artifactId>
-      <version>0.2.7</version>
+      <version>0.2.8</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/prime-mvc.iml
+++ b/prime-mvc.iml
@@ -137,11 +137,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.7/java-http-0.2.7.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.8/java-http-0.2.8.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.7/java-http-0.2.7-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.8/java-http-0.2.8-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.primeframework.mvc.parameter.annotation.FieldUnwrapped;
 /**
  * This class is an abstract implementation of the {@link MVCConfiguration} interface. It provides good default values
  * for most of the methods on that interface but leaves a few methods to be implemented by your application. To
- * accomplish this, sub-class this class and implement the missing methods. Then bind your implementation into the Guice
+ * accomplish this, subclass this class and implement the missing methods. Then bind your implementation into the Guice
  * injector using a Module.
  *
  * @author Brian Pontarelli
@@ -44,7 +44,7 @@ public abstract class AbstractMVCConfiguration implements MVCConfiguration {
 
   public String controlTemplateDirectory = "control-templates";
 
-  public boolean csrfEnabled = false;
+  public boolean csrfEnabled;
 
   public boolean emptyParametersAreNull = true;
 
@@ -54,7 +54,7 @@ public abstract class AbstractMVCConfiguration implements MVCConfiguration {
 
   public long fileUploadMaxSize = MAX_SIZE;
 
-  public boolean ignoreEmptyParameters = false;
+  public boolean ignoreEmptyParameters;
 
   public String localeCookieName = "prime-locale";
 

--- a/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,19 +25,19 @@ import io.fusionauth.http.Cookie.SameSite;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 
 /**
- * The main configuration interface for Prime that outlines all of the configurable values for the framework. This
+ * The main configuration interface for Prime that outlines all the configurable values for the framework. This
  * interface can easily be implemented to suit any needs in your application.
  *
  * @author Brian Pontarelli
  */
 public interface MVCConfiguration {
   /**
-   * @return Whether or not unknown parameters should be allowed or if they should throw an exception.
+   * @return True if unknown parameters should be allowed or if they should throw an exception.
    */
   boolean allowUnknownParameters();
 
   /**
-   * @return Whether or not auto HTML escaping will be enabled for all templates.
+   * @return True if auto HTML escaping will be enabled for all templates.
    */
   boolean autoHTMLEscapingEnabled();
 
@@ -57,7 +57,7 @@ public interface MVCConfiguration {
   Key cookieEncryptionKey();
 
   /**
-   * @return Whether or not the CSRF handling is enabled or not.
+   * @return True if CSRF handling is enabled or not.
    */
   boolean csrfEnabled();
 
@@ -135,7 +135,7 @@ public interface MVCConfiguration {
 
   /**
    * @return The number of seconds to check for Freemarker template updates (max integer means never and 0 means
-   *     always).
+   * always).
    */
   int templateCheckSeconds();
 
@@ -146,7 +146,7 @@ public interface MVCConfiguration {
 
   /**
    * @return The annotations that identify a field to be un-wrapped - or be considered transparent by the
-   *     {@link ExpressionEvaluator}.
+   * {@link ExpressionEvaluator}.
    */
   List<Class<? extends Annotation>> unwrapAnnotations();
 }

--- a/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
@@ -32,12 +32,12 @@ import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
  */
 public interface MVCConfiguration {
   /**
-   * @return True if unknown parameters should be allowed or if they should throw an exception.
+   * @return true if unknown parameters should be allowed, false if they are not allowed.
    */
   boolean allowUnknownParameters();
 
   /**
-   * @return True if auto HTML escaping will be enabled for all templates.
+   * @return true if auto HTML escaping will be enabled for all templates.
    */
   boolean autoHTMLEscapingEnabled();
 
@@ -57,12 +57,12 @@ public interface MVCConfiguration {
   Key cookieEncryptionKey();
 
   /**
-   * @return True if CSRF handling is enabled or not.
+   * @return true if CSRF handling is enabled.
    */
   boolean csrfEnabled();
 
   /**
-   * @return True if empty HTTP request parameters should be considered null values by the conversion system.
+   * @return true if empty HTTP request parameters should be considered null values by the conversion system.
    */
   boolean emptyParametersAreNull();
 

--- a/src/main/java/org/primeframework/mvc/guice/MVCModule.java
+++ b/src/main/java/org/primeframework/mvc/guice/MVCModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,12 +30,13 @@ import org.primeframework.mvc.message.scope.guice.ScopeModule;
 import org.primeframework.mvc.parameter.convert.guice.ConverterModule;
 import org.primeframework.mvc.parameter.guice.ParameterModule;
 import org.primeframework.mvc.security.guice.SecurityModule;
+import org.primeframework.mvc.security.guice.StaticResourceModule;
 import org.primeframework.mvc.util.guice.UtilModule;
 import org.primeframework.mvc.validation.guice.ValidationModule;
 import org.primeframework.mvc.workflow.guice.WorkflowModule;
 
 /**
- * A virtual module that installs all of the Prime MVC modules.
+ * A virtual module that installs all the Prime MVC modules.
  *
  * @author Brian Pontarelli
  */
@@ -56,6 +57,7 @@ public class MVCModule extends AbstractModule {
     install(new SecurityModule());
     install(new ScopeModule());
     install(new org.primeframework.mvc.scope.guice.ScopeModule());
+    install(new StaticResourceModule());
     install(new UtilModule());
     install(new ValidationModule());
     install(new WorkflowModule());

--- a/src/main/java/org/primeframework/mvc/security/DefaultStaticClasspathResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/DefaultStaticClasspathResourceFilter.java
@@ -15,6 +15,8 @@
  */
 package org.primeframework.mvc.security;
 
+import io.fusionauth.http.server.HTTPRequest;
+
 /**
  * The default filter behavior will block all requests. You will need to bind your own filter and explicitly allow some
  * or all requests based upon the URI.
@@ -23,7 +25,7 @@ package org.primeframework.mvc.security;
  */
 public class DefaultStaticClasspathResourceFilter implements StaticClasspathResourceFilter {
   @Override
-  public boolean allow(String uri) {
+  public boolean allow(String uri, HTTPRequest request) {
     // Loading resources from the class path is disabled by default.
     return false;
   }

--- a/src/main/java/org/primeframework/mvc/security/DefaultStaticClasspathResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/DefaultStaticClasspathResourceFilter.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+/**
+ * The default filter behavior will block all requests. You will need to bind your own filter and explicitly allow some
+ * or all requests based upon the URI.
+ *
+ * @author Daniel DeGroff
+ */
+public class DefaultStaticClasspathResourceFilter implements StaticClasspathResourceFilter {
+  @Override
+  public boolean allow(String uri) {
+    // Loading resources from the class path is disabled by default.
+    return false;
+  }
+}

--- a/src/main/java/org/primeframework/mvc/security/DefaultStaticResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/DefaultStaticResourceFilter.java
@@ -15,6 +15,7 @@
  */
 package org.primeframework.mvc.security;
 
+import io.fusionauth.http.server.HTTPRequest;
 import org.primeframework.mvc.config.MVCConfiguration;
 
 /**
@@ -25,7 +26,7 @@ import org.primeframework.mvc.config.MVCConfiguration;
  */
 public class DefaultStaticResourceFilter implements StaticResourceFilter {
   @Override
-  public boolean allow(String uri) {
+  public boolean allow(String uri, HTTPRequest request) {
     // Allow all resources to be loaded.
     return true;
   }

--- a/src/main/java/org/primeframework/mvc/security/DefaultStaticResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/DefaultStaticResourceFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+import org.primeframework.mvc.config.MVCConfiguration;
+
+/**
+ * The default behavior will be to load all static resources that can be resolved within the configured
+ * static resource directory as configured by {@link MVCConfiguration#staticDirectory()}.
+ *
+ * @author Daniel DeGroff
+ */
+public class DefaultStaticResourceFilter implements StaticResourceFilter {
+  @Override
+  public boolean allow(String uri) {
+    // Allow all resources to be loaded.
+    return true;
+  }
+}

--- a/src/main/java/org/primeframework/mvc/security/StaticClasspathResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/StaticClasspathResourceFilter.java
@@ -15,6 +15,8 @@
  */
 package org.primeframework.mvc.security;
 
+import io.fusionauth.http.server.HTTPRequest;
+
 /**
  * A filter for static resource requests that may be resolved through the class path.
  *
@@ -22,8 +24,9 @@ package org.primeframework.mvc.security;
  */
 public interface StaticClasspathResourceFilter {
   /**
-   * @param uri the request URI
+   * @param uri     the request URI
+   * @param request the request
    * @return true if resolution should be attempted using class path resolution.
    */
-  boolean allow(String uri);
+  boolean allow(String uri, HTTPRequest request);
 }

--- a/src/main/java/org/primeframework/mvc/security/StaticClasspathResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/StaticClasspathResourceFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+/**
+ * A filter for static resource requests that may be resolved through the class path.
+ *
+ * @author Daniel DeGroff
+ */
+public interface StaticClasspathResourceFilter {
+  /**
+   * @param uri the request URI
+   * @return true if resolution should be attempted using class path resolution.
+   */
+  boolean allow(String uri);
+}

--- a/src/main/java/org/primeframework/mvc/security/StaticResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/StaticResourceFilter.java
@@ -15,6 +15,8 @@
  */
 package org.primeframework.mvc.security;
 
+import io.fusionauth.http.server.HTTPRequest;
+
 /**
  * A filter for static resource requests.
  *
@@ -22,8 +24,9 @@ package org.primeframework.mvc.security;
  */
 public interface StaticResourceFilter {
   /**
-   * @param uri the request URI
+   * @param uri     the request URI
+   * @param request the request
    * @return true if resolution should be attempted using the configured static resource directory.
    */
-  boolean allow(String uri);
+  boolean allow(String uri, HTTPRequest request);
 }

--- a/src/main/java/org/primeframework/mvc/security/StaticResourceFilter.java
+++ b/src/main/java/org/primeframework/mvc/security/StaticResourceFilter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+/**
+ * A filter for static resource requests.
+ *
+ * @author Daniel DeGroff
+ */
+public interface StaticResourceFilter {
+  /**
+   * @param uri the request URI
+   * @return true if resolution should be attempted using the configured static resource directory.
+   */
+  boolean allow(String uri);
+}

--- a/src/main/java/org/primeframework/mvc/security/guice/StaticResourceModule.java
+++ b/src/main/java/org/primeframework/mvc/security/guice/StaticResourceModule.java
@@ -22,6 +22,8 @@ import org.primeframework.mvc.security.StaticClasspathResourceFilter;
 import org.primeframework.mvc.security.StaticResourceFilter;
 
 /**
+ * A guice module for static resource configuration.
+ *
  * @author Daniel DeGroff
  */
 public class StaticResourceModule extends AbstractModule {

--- a/src/main/java/org/primeframework/mvc/security/guice/StaticResourceModule.java
+++ b/src/main/java/org/primeframework/mvc/security/guice/StaticResourceModule.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security.guice;
+
+import com.google.inject.AbstractModule;
+import org.primeframework.mvc.security.DefaultStaticClasspathResourceFilter;
+import org.primeframework.mvc.security.DefaultStaticResourceFilter;
+import org.primeframework.mvc.security.StaticClasspathResourceFilter;
+import org.primeframework.mvc.security.StaticResourceFilter;
+
+/**
+ * @author Daniel DeGroff
+ */
+public class StaticResourceModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(StaticResourceFilter.class).to(DefaultStaticResourceFilter.class);
+    bind(StaticClasspathResourceFilter.class).to(DefaultStaticClasspathResourceFilter.class);
+  }
+}

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -348,6 +348,18 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
+  public void get_action_unknownParameters() throws Exception {
+    // simulate a development runtime
+    configuration.allowUnknownParameters = false;
+
+    // Even though the global config does not allow unknown parameters, this action does.
+    test.simulate(() -> simulator.test("/allow-unknown-parameters")
+                                 .withURLParameter("foo", "bar")
+                                 .get()
+                                 .assertStatusCode(200));
+  }
+
+  @Test
   public void get_collectionConverter() throws Exception {
     // Both of these will fail because the action has a List<String> as the backing values for this form, and the input field is a text field.
     test.simulate(() -> simulator.test("/collection-converter")
@@ -571,18 +583,6 @@ public class GlobalTest extends PrimeBaseTest {
     simulator.test("/user/full-form")
              .get()
              .assertBodyFile(Path.of("src/test/resources/html/full-form.html"));
-  }
-
-  @Test
-  public void get_action_unknownParameters() throws Exception {
-    // simulate a development runtime
-    configuration.allowUnknownParameters = false;
-
-    // Even though the global config does not allow unknown parameters, this action does.
-    test.simulate(() -> simulator.test("/allow-unknown-parameters")
-                                 .withURLParameter("foo", "bar")
-                                 .get()
-                                 .assertStatusCode(200));
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/MockConfiguration.java
+++ b/src/test/java/org/primeframework/mvc/MockConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -75,7 +75,11 @@ import org.primeframework.mvc.message.scope.FlashScope;
 import org.primeframework.mvc.message.scope.RequestScope;
 import org.primeframework.mvc.security.CipherProvider;
 import org.primeframework.mvc.security.DefaultCipherProvider;
+import org.primeframework.mvc.security.MockStaticClasspathResourceFilter;
+import org.primeframework.mvc.security.MockStaticResourceFilter;
 import org.primeframework.mvc.security.MockUserLoginSecurityContext;
+import org.primeframework.mvc.security.StaticClasspathResourceFilter;
+import org.primeframework.mvc.security.StaticResourceFilter;
 import org.primeframework.mvc.security.UserLoginSecurityContext;
 import org.primeframework.mvc.security.VerifierProvider;
 import org.primeframework.mvc.security.csrf.CSRFProvider;
@@ -221,7 +225,7 @@ public abstract class PrimeBaseTest {
     };
 
     Module module = Modules.override(mvcModule).with(new TestContentModule(), new TestSecurityModule(), new TestScopeModule(),
-                                                     new TestWorkflowModule());
+                                                     new TestWorkflowModule(), new TestStaticResourceModule());
     var mainConfig = new HTTPServerConfiguration().withClientTimeout(Duration.ofMillis(500))
                                                   .withListener(new HTTPListenerConfiguration(9080))
                                                   .withLoggerFactory(TestAccumulatingLoggerFactory.FACTORY);
@@ -443,6 +447,14 @@ public abstract class PrimeBaseTest {
       // Don't bind as a singleton in tests so that I can change the key during a test
       bind(CipherProvider.class).to(DefaultCipherProvider.class);
       bind(VerifierProvider.class).to(MockVerifierProvider.class);
+    }
+  }
+
+  public static class TestStaticResourceModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      bind(StaticResourceFilter.class).to(MockStaticResourceFilter.class);
+      bind(StaticClasspathResourceFilter.class).to(MockStaticClasspathResourceFilter.class);
     }
   }
 

--- a/src/test/java/org/primeframework/mvc/StaticResourceTest.java
+++ b/src/test/java/org/primeframework/mvc/StaticResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,48 @@
  */
 package org.primeframework.mvc;
 
+import org.primeframework.mvc.security.MockStaticClasspathResourceFilter;
+import org.primeframework.mvc.security.MockStaticResourceFilter;
 import org.testng.annotations.Test;
 
 /**
  * @author Brian Pontarelli
  */
 public class StaticResourceTest extends PrimeBaseTest {
+  @Test
+  public void get_classpath_resolution() {
+    // The default filter will deny all requests for class path resolution.
+    // - Unless this exists in the configured static directory, it will always be a 404.
+    simulator.test("/control-templates/button.ftl")
+             .get()
+             .assertStatusCode(404);
+
+    // Allow *.ftl resources through the filter
+    MockStaticClasspathResourceFilter.TestFunction = uri -> uri.endsWith(".ftl");
+
+    simulator.test("/control-templates/button.ftl")
+             .get()
+             .assertStatusCode(200)
+             .assertContentType("content/unknown")
+             .assertBodyContains("[#ftl/]")
+             .assertContentLength(470);
+
+    // We used to ignore .class URIs by default. We still do, but no longer explicitly. The class path resolution rejects everything by default.
+    // - Ensure we can't look this up w/out modifying the filter.
+    simulator.test("/org/primeframework/mvc/PrimeMVCRequestHandler.class")
+             .get()
+             .assertStatusCode(404);
+
+    // Allow *.class resources through the filter
+    MockStaticClasspathResourceFilter.TestFunction = uri -> uri.endsWith(".class");
+
+    // Not sure why you'd want to do this, but it is up to the user to configure the filter.
+    simulator.test("/org/primeframework/mvc/PrimeMVCRequestHandler.class")
+             .get()
+             .assertStatusCode(200)
+             .assertContentLength(3176);
+  }
+
   @Test
   public void get_large_resource() {
     simulator.test("/css/fusionauth-style.css")
@@ -49,6 +85,14 @@ public class StaticResourceTest extends PrimeBaseTest {
              .get()
              .assertStatusCode(200)
              .assertContentType("text/javascript")
-             .assertBodyContains("{};");
+             .assertBodyContains("{};")
+             .assertContentLength(3);
+
+    // Disable .js resolution in the static resource directory
+    MockStaticResourceFilter.TestFunction = uri -> !uri.endsWith(".js");
+
+    simulator.test("/js/test.js")
+             .get()
+             .assertStatusCode(404);
   }
 }

--- a/src/test/java/org/primeframework/mvc/security/MockStaticClasspathResourceFilter.java
+++ b/src/test/java/org/primeframework/mvc/security/MockStaticClasspathResourceFilter.java
@@ -17,6 +17,8 @@ package org.primeframework.mvc.security;
 
 import java.util.function.Function;
 
+import io.fusionauth.http.server.HTTPRequest;
+
 /**
  * @author Daniel DeGroff
  */
@@ -24,11 +26,11 @@ public class MockStaticClasspathResourceFilter extends DefaultStaticClasspathRes
   public static Function<String, Boolean> TestFunction;
 
   @Override
-  public boolean allow(String uri) {
+  public boolean allow(String uri, HTTPRequest request) {
     if (TestFunction != null) {
       return TestFunction.apply(uri);
     }
 
-    return super.allow(uri);
+    return super.allow(uri, request);
   }
 }

--- a/src/test/java/org/primeframework/mvc/security/MockStaticClasspathResourceFilter.java
+++ b/src/test/java/org/primeframework/mvc/security/MockStaticClasspathResourceFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+import java.util.function.Function;
+
+/**
+ * @author Daniel DeGroff
+ */
+public class MockStaticClasspathResourceFilter extends DefaultStaticClasspathResourceFilter {
+  public static Function<String, Boolean> TestFunction;
+
+  @Override
+  public boolean allow(String uri) {
+    if (TestFunction != null) {
+      return TestFunction.apply(uri);
+    }
+
+    return super.allow(uri);
+  }
+}

--- a/src/test/java/org/primeframework/mvc/security/MockStaticResourceFilter.java
+++ b/src/test/java/org/primeframework/mvc/security/MockStaticResourceFilter.java
@@ -17,6 +17,8 @@ package org.primeframework.mvc.security;
 
 import java.util.function.Function;
 
+import io.fusionauth.http.server.HTTPRequest;
+
 /**
  * @author Daniel DeGroff
  */
@@ -24,11 +26,11 @@ public class MockStaticResourceFilter extends DefaultStaticResourceFilter {
   public static Function<String, Boolean> TestFunction;
 
   @Override
-  public boolean allow(String uri) {
+  public boolean allow(String uri, HTTPRequest request) {
     if (TestFunction != null) {
       return TestFunction.apply(uri);
     }
 
-    return super.allow(uri);
+    return super.allow(uri, request);
   }
 }

--- a/src/test/java/org/primeframework/mvc/security/MockStaticResourceFilter.java
+++ b/src/test/java/org/primeframework/mvc/security/MockStaticResourceFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+import java.util.function.Function;
+
+/**
+ * @author Daniel DeGroff
+ */
+public class MockStaticResourceFilter extends DefaultStaticResourceFilter {
+  public static Function<String, Boolean> TestFunction;
+
+  @Override
+  public boolean allow(String uri) {
+    if (TestFunction != null) {
+      return TestFunction.apply(uri);
+    }
+
+    return super.allow(uri);
+  }
+}


### PR DESCRIPTION
Add static resource filters to allow each request to optionally reject based upon the URI

- Allow allow resources in the configured static resource directory by default. 
- Reject all resources in the class path by default. 
- Allow filters to be bound to control each of these two paths.