### PR TITLE
Fail faster on login when using a JWT security context

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.17.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.18.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.17.0</version>
+  <version>4.18.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/security/InvalidLoginContext.java
+++ b/src/main/java/org/primeframework/mvc/security/InvalidLoginContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2023, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.security;
+
+import org.primeframework.mvc.ErrorException;
+
+/**
+ * Thrown when the login context provided to the {@link UserLoginSecurityContext} is invalid.
+ *
+ * @author Daniel DeGroff
+ */
+public class InvalidLoginContext extends ErrorException {
+  public InvalidLoginContext() {
+    super("unauthenticated");
+  }
+}

--- a/src/test/java/org/example/action/oauth/LoginAction.java
+++ b/src/test/java/org/example/action/oauth/LoginAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,10 @@ import org.primeframework.mvc.security.UserLoginSecurityContext;
 import org.primeframework.mvc.security.oauth.Tokens;
 
 @Action
-@Status
+@Status.List({
+    @Status,
+    @Status(code = "unauthenticated", status = 401)
+})
 public class LoginAction {
   public static final String Subject = UUID.randomUUID().toString();
 
@@ -47,7 +50,8 @@ public class LoginAction {
   public String post() {
     JWT jwt = new JWT();
     jwt.audience = "prime-tests";
-    jwt.expiration = expired ? ZonedDateTime.now(ZoneOffset.UTC).minusMinutes(1) : ZonedDateTime.now(ZoneOffset.UTC).plusMinutes(1);
+    jwt.issuedAt = ZonedDateTime.now(ZoneOffset.UTC);
+    jwt.expiration = expired ? jwt.issuedAt.minusMinutes(1) : jwt.issuedAt.plusMinutes(1);
     jwt.issuer = "Prime";
     jwt.subject = Subject;
 

--- a/src/test/java/org/example/action/oauth/TokenAction.java
+++ b/src/test/java/org/example/action/oauth/TokenAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ public class TokenAction {
 
     JWT jwt = new JWT();
     jwt.audience = "prime-tests";
-    jwt.expiration = ZonedDateTime.now(ZoneOffset.UTC).plusMinutes(1);
+    jwt.issuedAt = ZonedDateTime.now(ZoneOffset.UTC);
+    jwt.expiration = jwt.issuedAt.plusMinutes(1);
     jwt.issuer = "Prime";
     jwt.subject = Subject;
 

--- a/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
+++ b/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
@@ -150,7 +150,7 @@ public class JWTRefreshTokenLoginTest {
 
   @Test
   public void refreshTokenEndpointDown() {
-    // By default, the Token endpoint int he MockUserLoginSecurityContext is configured to a port that is not listening. So it is 'down'.
+    // By default, the Token endpoint in the MockUserLoginSecurityContext is configured to a port that is not listening. So it is 'down'.
     MockOAuthUserLoginSecurityContext.ValidateJWTOnLogin = false;
 
     // Setting 'expired: true' on the request just tells the Login action to create an expired JWT and store it in the LoginContext.

--- a/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
+++ b/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+/**
+ * @author Brian Pontarelli
+ */
 public class JWTRefreshTokenLoginTest {
   protected final static TestMessageObserver messageObserver = new TestMessageObserver();
 
@@ -112,8 +115,8 @@ public class JWTRefreshTokenLoginTest {
     MockOAuthUserLoginSecurityContext.Roles.clear();
     MockOAuthUserLoginSecurityContext.CurrentUser = null;
 
-    // Reset the token endpoint
-    MockOAuthUserLoginSecurityContext.TokenEndpoint = "http://localhost:8000/oauth/token";
+    // Reset the token endpoint.
+    MockOAuthUserLoginSecurityContext.reset();
   }
 
   @Test
@@ -129,6 +132,15 @@ public class JWTRefreshTokenLoginTest {
   }
 
   @Test
+  public void login_expired() {
+    // The JWT will be validated for expiration when you login, expect an expired JWT to fail immediately.
+    simulator.test("/oauth/login")
+             .withParameter("expired", "true")
+             .post()
+             .assertStatusCode(401);
+  }
+
+  @Test
   public void notLoggedIn() {
     simulator.test("/oauth/protected-resource")
              .get()
@@ -138,6 +150,11 @@ public class JWTRefreshTokenLoginTest {
 
   @Test
   public void refreshTokenEndpointDown() {
+    // By default, the Token endpoint int he MockUserLoginSecurityContext is configured to a port that is not listening. So it is 'down'.
+    MockOAuthUserLoginSecurityContext.ValidateJWTOnLogin = false;
+
+    // Setting 'expired: true' on the request just tells the Login action to create an expired JWT and store it in the LoginContext.
+    // - So we expect this to succeed, but the login context wil now contain an expired JWT. This means it will be refreshed on first use.
     simulator.test("/oauth/login")
              .withParameter("expired", "true")
              .post()
@@ -151,13 +168,18 @@ public class JWTRefreshTokenLoginTest {
 
   @Test
   public void refreshTokenEndpointUp() {
+    MockOAuthUserLoginSecurityContext.ValidateJWTOnLogin = false;
     MockOAuthUserLoginSecurityContext.TokenEndpoint = "http://localhost:" + simulator.getPort() + "/oauth/token";
 
+    // Setting 'expired: true' on the request just tells the Login action to create an expired JWT and store it in the LoginContext.
+    // - So we expect this to succeed, but the login context wil now contain an expired JWT. This means it will be refreshed on first use.
     simulator.test("/oauth/login")
              .withParameter("expired", "true")
              .post()
              .assertStatusCode(200);
 
+    // The JWT in the security context was found to be expired on first use even though login succeeded.
+    // - This will have caused us to refresh the token, so this action should succeed.
     simulator.test("/oauth/protected-resource")
              .get()
              .assertStatusCode(200)

--- a/src/test/java/org/primeframework/mvc/test/RequestSimulator.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestSimulator.java
@@ -101,12 +101,13 @@ public class RequestSimulator {
   }
 
   /**
-   * The RequestBuilder port. Available only after an invocation of {@link #test(String)}.
+   * The RequestBuilder port.
    *
    * @return The port that the RequestBuilder is using.
    */
   public int getPort() {
-    return actualPort;
+    // Default to the configured port if we have not yet actualPort.
+    return actualPort != -1 ? actualPort : port;
   }
 
   public void reset() {


### PR DESCRIPTION
Fail faster on login when when using the RefreshTokenCookiesUserLoginSecurityContext

This change is to just fail faster. In practice we don't expect the `login()` method to be passed an expired token, but let's check anyway. Also, allow the implementor to verify application specific claims on login as well. This just ensures the initial login context is clean. 

Also, re-run any application specific claim validation on each refresh. 

Lastly, add a new virtual method for a revocation check. This just allows the implementor to separate out these two steps if they wish. 