### PR TITLE
Only allow SaveRequest on POST on same origin and if explicitly allowed.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.18.2", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.19.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,12 @@
 <!--
   ~ Copyright (c) 2023, FusionAuth, All Rights Reserved
-  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.18.2</version>
+  <version>4.19.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
+++ b/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
@@ -147,6 +147,8 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
 
   public static class SaveRequestImpl implements SaveRequest {
 
+    private final boolean allowPost;
+
     private final String cacheControl;
 
     private final String code;
@@ -159,15 +161,14 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
 
     private final String uri;
 
-    private boolean allowPost;
-
-    public SaveRequestImpl(String uri, String code, boolean perm, boolean encode) {
+    public SaveRequestImpl(String uri, String code, boolean perm, boolean encode, boolean allowPost) {
       this.cacheControl = "no-cache";
       this.code = code;
       this.disableCacheControl = false;
       this.encode = encode;
       this.uri = uri;
       this.perm = perm;
+      this.allowPost = allowPost;
     }
 
     @Override

--- a/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
+++ b/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,8 +70,8 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
     // GET requests are always ok.
     boolean saveRequestAllowed = HTTPMethod.GET.is(method);
 
-    // When performing a saved request on a POST, ensure it is same origin
-    if (HTTPMethod.POST.is(method)) {
+    // When performing a saved request on a POST, ensure it is same origin if explicitly allowed by the annotation.
+    if (HTTPMethod.POST.is(method) && saveRequest.allowPost()) {
       String source = HTTPTools.getOriginHeader(request);
       if (source != null) {
         URI uri = URI.create(request.getBaseURL());
@@ -146,6 +146,7 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
   }
 
   public static class SaveRequestImpl implements SaveRequest {
+
     private final String cacheControl;
 
     private final String code;
@@ -158,6 +159,8 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
 
     private final String uri;
 
+    private boolean allowPost;
+
     public SaveRequestImpl(String uri, String code, boolean perm, boolean encode) {
       this.cacheControl = "no-cache";
       this.code = code;
@@ -165,6 +168,11 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
       this.encode = encode;
       this.uri = uri;
       this.perm = perm;
+    }
+
+    @Override
+    public boolean allowPost() {
+      return allowPost;
     }
 
     public Class<? extends Annotation> annotationType() {

--- a/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
+++ b/src/main/java/org/primeframework/mvc/action/result/SaveRequestResult.java
@@ -85,7 +85,7 @@ public class SaveRequestResult extends AbstractRedirectResult<SaveRequest> {
     if (saveRequestAllowed) {
       Map<String, List<String>> requestParameters = null;
       String redirectURI;
-      if (HTTPMethod.GET.is(request.getMethod())) {
+      if (HTTPMethod.GET.is(method)) {
         Map<String, List<String>> params = request.getParameters();
         redirectURI = request.getPath() + makeQueryString(params);
       } else {

--- a/src/main/java/org/primeframework/mvc/action/result/annotation/SaveRequest.java
+++ b/src/main/java/org/primeframework/mvc/action/result/annotation/SaveRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,16 +54,16 @@ public @interface SaveRequest {
   boolean disableCacheControl() default false;
 
   /**
-   * @return Whether or not variable replacements inside the URI string should be encoded or not. In some cases, you
+   * @return Whether variable replacements inside the URI string should be encoded or not. In some cases, you
    *     want to encode variables when they contain UTF-8 characters and are part of the URL query parameters. For
    *     example, "/foo?user=${bar}" and the bar variable contains unicode characters. In other cases, you don't want to
    *     encode the variables. For example, if they variable contains the entire URI such as "${uri}". This defaults to
-   *     false to maintain backwards compatibility.
+   *     false in order to maintain backwards compatibility.
    */
   boolean encodeVariables() default false;
 
   /**
-   * @return Whether or not this is a permanent redirect (301) or a temporary redirect (302).
+   * @return Whether this is a permanent redirect (301) or a temporary redirect (302).
    */
   boolean perm() default false;
 

--- a/src/main/java/org/primeframework/mvc/action/result/annotation/SaveRequest.java
+++ b/src/main/java/org/primeframework/mvc/action/result/annotation/SaveRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface SaveRequest {
+  /**
+   * If true then SavedRequest will be performed on a POST request as long as it is a same-origin request. Otherwise, only GET calls are allowed.
+   * Defaults to false.
+   *
+   * @return set to true to allow POST.
+   */
+  boolean allowPost() default false;
+
   /**
    * @return the value to use for the <code>Cache-Control</code> header.
    */

--- a/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
@@ -64,7 +64,7 @@ public abstract class AbstractMVCConfiguration implements MVCConfiguration {
 
   public String missingPath = "/missing";
 
-  public int savedRequestCookieMaximumSize = 16 * 1024; // 6 KB
+  public int savedRequestCookieMaximumSize = 16 * 1024; // 16 KB
 
   public String savedRequestCookieName = "prime-mvc-saved-request";
 

--- a/src/test/java/org/example/action/store/AllowPostPurchaseAction.java
+++ b/src/test/java/org/example/action/store/AllowPostPurchaseAction.java
@@ -15,16 +15,32 @@
  */
 package org.example.action.store;
 
+import javax.inject.Inject;
+
+import org.primeframework.mvc.action.annotation.Action;
+import org.primeframework.mvc.action.result.annotation.Forward;
 import org.primeframework.mvc.action.result.annotation.SaveRequest;
+import org.primeframework.mvc.message.MessageStore;
 
 /**
- * @author Daniel DeGroff
+ * @author Lyle Schemmerling
  */
-@SaveRequest(uri = "/store/login")
-public abstract class BaseStoreAction {
-  public static boolean loggedIn;
+@Action
+@SaveRequest(uri = "/store/login", allowPost = true)
+@Forward(page = "/store/purchase.ftl")
+public class AllowPostPurchaseAction extends PurchaseAction {
 
-  protected boolean isLoggedIn() {
-    return loggedIn;
+  @Inject
+  public AllowPostPurchaseAction(MessageStore messageStore) {
+    super(messageStore);
   }
+
+  public String get() {
+    return super.get();
+  }
+
+  public String post() {
+    return super.post();
+  }
+
 }

--- a/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
+++ b/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ public class SaveRequestResultTest extends PrimeBaseTest {
 
   @Test
   public void saveRequestPOST_tooBig() throws IOException {
-    // By default Tomcat limits the HTTP Header to 8 KB (see Tomcat maxHttpHeaderSize)
+    // By default, Tomcat limits the HTTP Header to 8 KB (see Tomcat maxHttpHeaderSize)
     // If we think we might be surpassing that size, we should skip the save request otherwise we'll return a 500 to the client
 
     ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);

--- a/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
+++ b/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2015-2023, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,10 +103,9 @@ public class SaveRequestResultTest extends PrimeBaseTest {
     SaveRequestResult result = new SaveRequestResult(messageStore, expressionEvaluator, response, request, store, configuration, encryptor, objectMapper);
     result.execute(annotation);
 
-    // The cookie value will be different each time because the initialization vector is unique per request. Decrypt the actual value to compare it to the expected.
-    SavedHttpRequest actual = CookieTools.fromJSONCookie(response.getCookies().get(0).value, SavedHttpRequest.class, true, encryptor, objectMapper);
-    SavedHttpRequest expected = new SavedHttpRequest(HTTPMethod.POST, "/test", request.getParameters());
-    assertEquals(actual, expected);
+    // Note that POST does not work with saved request, so expect it to not work at all yo.
+    assertEquals(simulator.userAgent.getCookies(request), List.of());
+    assertEquals(response.getRedirect(), "/login");
 
     assertEquals(response.getRedirect(), "/login");
 


### PR DESCRIPTION
In order to prevent CSRF attacks only allow replaying a saved request on a POST if the request is on the same origin, by checking the origin/referer header AND if the annotation explicitly has the option turned on.

There is a new parameter on `SaveRequest` called `allowPost` with a default of `false`.

If set to `true` then the origin header is checked and if it is allowed then the saved request will be honored. 