### PR TITLE
Fix NPE with empty body

### DIFF
--- a/src/main/java/org/primeframework/mvc/content/binary/BinaryContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/binary/BinaryContentHandler.java
@@ -79,8 +79,8 @@ public class BinaryContentHandler implements ContentHandler {
       return;
     }
 
-    long contentLength = request.getContentLength();
-    if (contentLength == 0) {
+    Long contentLength = request.getContentLength();
+    if (contentLength == null || contentLength == 0) {
       return;
     }
 

--- a/src/test/java/org/example/action/BinaryAction.java
+++ b/src/test/java/org/example/action/BinaryAction.java
@@ -33,7 +33,7 @@ import static org.testng.AssertJUnit.assertNull;
 @Status
 public class BinaryAction {
   public String expected;
-  public boolean expectedNullFile = false;
+  public boolean expectedNullFile;
 
   @BinaryRequest
   public Path file;

--- a/src/test/java/org/example/action/BinaryAction.java
+++ b/src/test/java/org/example/action/BinaryAction.java
@@ -24,6 +24,7 @@ import org.primeframework.mvc.action.result.annotation.Status;
 import org.primeframework.mvc.content.binary.annotation.BinaryRequest;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.AssertJUnit.assertNull;
 
 /**
  * @author Daniel DeGroff
@@ -32,11 +33,16 @@ import static org.testng.Assert.assertNotNull;
 @Status
 public class BinaryAction {
   public String expected;
+  public boolean expectedNullFile = false;
 
   @BinaryRequest
   public Path file;
 
   public String post() {
+    if (expectedNullFile) {
+      assertNull(file);
+      return "success";
+    }
     assertNotNull(expected, "You need to pass in the expected value on the request.");
     assertNotNull(file);
     try {

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -1449,6 +1449,16 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
+  public void post_binary_no_body() throws Exception {
+    test.simulate(() -> simulator.test("/binary")
+                                 .withURLParameter("expectedNullFile", "true")
+                                 .withContentType("application/octet-stream")
+                                 .post()
+                                 .assertStatusCode(200)
+                                 .assertHeaderContains("Cache-Control", "no-cache"));
+  }
+
+  @Test
   public void post_chunked_json() throws Exception {
     // Our simulator does not chunk. This test uses the Java HTTP client to test chunking with Content-Type: application/json
     HttpClient client = HttpClient.newBuilder()


### PR DESCRIPTION
First test commit replicates issue where the `Long` that comes back from `request.getContentLength()` is null, which the handler is not expecting, so even a Prime MVC app's attempt to handle this by checking the field for null never happens since the `get()` or `post()` method does not run.

It's also possible to just treat this is a more deliberate error from Prime MVC's standpoint and complain about an empty body. Open to suggestions.