### PR TITLE
Swap out the REST client in the simulator.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -19,7 +19,7 @@ dropWizardVersion = "3.2.6"
 easyMockVersion = "5.1.0"
 freemarkerVersion = "2.3.32"
 fusionAuthJWTVersion = "5.1.0"
-javaHTTPVersion = "0.2.8"
+javaHTTPVersion = "0.3.1-{integration}"
 jsonPatchVersion = "1.13.0"
 guavaVersion = "32.1.2-jre"
 guiceVersion = "6.0.0"
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.22.3", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.22.4", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ dropWizardVersion = "3.2.6"
 easyMockVersion = "5.1.0"
 freemarkerVersion = "2.3.32"
 fusionAuthJWTVersion = "5.1.0"
-javaHTTPVersion = "0.3.1-{integration}"
+javaHTTPVersion = "0.3.1"
 jsonPatchVersion = "1.13.0"
 guavaVersion = "32.1.2-jre"
 guiceVersion = "6.0.0"

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>java-http</artifactId>
-      <version>0.3.1-{integration}</version>
+      <version>0.3.1</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.22.2</version>
+  <version>4.22.4</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.fusionauth</groupId>
       <artifactId>java-http</artifactId>
-      <version>0.2.8</version>
+      <version>0.3.1-{integration}</version>
       <type>jar</type>
       <scope>compile</scope>
       <optional>false</optional>

--- a/prime-mvc.iml
+++ b/prime-mvc.iml
@@ -137,11 +137,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/io/fusionauth/java-http/0.3.1-{integration}/java-http-0.3.1-{integration}.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.3.1/java-http-0.3.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/io/fusionauth/java-http/0.3.1-{integration}/java-http-0.3.1-{integration}-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.3.1/java-http-0.3.1-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/prime-mvc.iml
+++ b/prime-mvc.iml
@@ -137,11 +137,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.8/java-http-0.2.8.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/io/fusionauth/java-http/0.3.1-{integration}/java-http-0.3.1-{integration}.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/0.2.8/java-http-0.2.8-src.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/io/fusionauth/java-http/0.3.1-{integration}/java-http-0.3.1-{integration}-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/prime-mvc.ipr
+++ b/prime-mvc.ipr
@@ -102,6 +102,13 @@
         <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
         <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
       </inspection_tool>
+      <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="ignoredTypes">
+          <set>
+            <option value="java.util.List" />
+          </set>
+        </option>
+      </inspection_tool>
       <inspection_tool class="fcd36335-ac86-4bef-8d30-062d8aae0364_CryptoCipherInsecureAsymmetricCryptographicAlgorithm" enabled="true" level="SENSEI ERROR" enabled_by_default="true" />
       <inspection_tool class="fcd36335-ac86-4bef-8d30-062d8aae0364_CryptoKeyAgreementGuideonApprovedCryptographicAlgorithm" enabled="true" level="SENSEI MARKED INFO" enabled_by_default="true" />
       <inspection_tool class="fcd36335-ac86-4bef-8d30-062d8aae0364_CryptoKeyAgreementInsecureCryptographicAlgorithm" enabled="true" level="SENSEI ERROR" enabled_by_default="true" />

--- a/src/test/java/org/primeframework/mvc/TLSTest.java
+++ b/src/test/java/org/primeframework/mvc/TLSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.primeframework.mvc;
 
-import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import java.io.IOException;
@@ -62,7 +61,9 @@ public class TLSTest {
     simulator.shutdown();
 
     try {
-      SSLContext.getInstance("SSL").init(null, null, null);
+      SSLContext sslContext = SSLContext.getInstance("SSL");
+      sslContext.init(null, null, null);
+      SSLContext.setDefault(sslContext);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -99,7 +100,7 @@ public class TLSTest {
     try {
       SSLContext context = SSLContext.getInstance("SSL");
       context.init(null, new TrustManager[]{new UnsafeTrustManager()}, null);
-      HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+      SSLContext.setDefault(context);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/primeframework/mvc/test/HTTPResponseWrapper.java
+++ b/src/test/java/org/primeframework/mvc/test/HTTPResponseWrapper.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.test;
+
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.inversoft.http.HTTPStrings;
+import io.fusionauth.http.Cookie;
+
+/**
+ * Test container for the HTTP Response and exception.
+ *
+ * @author Daniel DeGroff
+ */
+public class HTTPResponseWrapper {
+  public Throwable exception;
+
+  public Map<String, List<String>> headers;
+
+  public HttpResponse<byte[]> response;
+
+  public int status;
+
+  public byte[] getBody() {
+    return response != null
+        ? response.body()
+        : null;
+  }
+
+  public List<Cookie> getCookies(String name) {
+    return getCookies()
+        .stream()
+        .filter(c -> c.name.equals(name))
+        .toList();
+  }
+
+  public List<Cookie> getCookies() {
+    if (response == null) {
+      return List.of();
+    }
+
+    List<String> cookies = response.headers().allValues(HTTPStrings.Headers.SetCookie.toLowerCase());
+    if (cookies != null && cookies.size() > 0) {
+      return cookies.stream()
+                    .map(Cookie::fromResponseHeader)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+    }
+
+    return List.of();
+  }
+
+  public String getHeader(String name) {
+    return response != null
+        ? response.headers().firstValue(name.toLowerCase()).orElse(null)
+        : null;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public void init() {
+    status = response != null ? response.statusCode() : -1;
+    headers = response != null ? response.headers().map() : Map.of();
+  }
+}


### PR DESCRIPTION
Restify used HttpURLConnection which is fast, but has undesired side effects.

This means we don’t have to fight with `GET`’s changing to `POST`s. I tried to use their cookie manager instead of our Mock Use Agent, but the JDK cookie object still doesn’t support SameSite. :disappointed: Lame. 


### Related
- https://github.com/FusionAuth/java-http/pull/20
- https://github.com/inversoft/inversoft-maintenance-mode/pull/5
- https://github.com/inversoft/inversoft-api-authentication/pull/3