### PR TITLE
Copy request bodies from RequestBuilder to HTTPRequest for testing

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -30,7 +30,7 @@ restifyVersion = "4.1.2"
 slf4jVersion = "2.0.7"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.22.4", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.22.5", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:


### PR DESCRIPTION
Ran into an issue with a recent change because the request data is no longer available in the `RequestResult`'s `HTTPRequest` object when using the simulator.

This change copies the request body into the `HTTPRequest` in order to make it available to the test after the request is run.