### PR TITLE
Fix query String parser. A value may contain an equals sign.

### DIFF
--- a/src/main/java/org/primeframework/mvc/util/QueryStringTools.java
+++ b/src/main/java/org/primeframework/mvc/util/QueryStringTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2019-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class QueryStringTools {
     try {
       String[] parts = query.split("&");
       for (String part : parts) {
-        String[] pieces = part.split("=");
+        String[] pieces = part.split("=", 2);
         String name = URLDecoder.decode(pieces[0], StandardCharsets.UTF_8);
         String value = pieces.length > 1 ? URLDecoder.decode(pieces[1], StandardCharsets.UTF_8) : "";
         parameters.computeIfAbsent(name, k -> new ArrayList<>()).add(value);

--- a/src/test/java/org/primeframework/mvc/util/QueryStringToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/util/QueryStringToolsTest.java
@@ -41,5 +41,11 @@ public class QueryStringToolsTest {
     assertEquals(QueryStringTools.parseQueryString("foo=bar="), Map.of("foo", List.of("bar=")));
     assertEquals(QueryStringTools.parseQueryString("foo=bar=baz=&bar=foo=baz="), Map.of("foo", List.of("bar=baz="),
                                                                                         "bar", List.of("foo=baz=")));
+
+    // Name w/out value
+    assertEquals(QueryStringTools.parseQueryString("foo="), Map.of("foo", List.of("")));
+
+    // Multiple values
+    assertEquals(QueryStringTools.parseQueryString("foo=bar&foo=bar"), Map.of("foo", List.of("bar", "bar")));
   }
 }

--- a/src/test/java/org/primeframework/mvc/util/QueryStringToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/util/QueryStringToolsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.util;
+
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * @author Daniel DeGroff
+ */
+public class QueryStringToolsTest {
+  @Test
+  public void parseQueryString() {
+    // Value w/out equals in the value
+    assertEquals(QueryStringTools.parseQueryString("foo=bar"), Map.of("foo", List.of("bar")));
+    assertEquals(QueryStringTools.parseQueryString("foo=bar&bar=bar"), Map.of("foo", List.of("bar"),
+                                                                              "bar", List.of("bar")));
+
+    // Value that contain an equals sign
+    assertEquals(QueryStringTools.parseQueryString("foo=bar="), Map.of("foo", List.of("bar=")));
+    assertEquals(QueryStringTools.parseQueryString("foo=bar=&bar=bar="), Map.of("foo", List.of("bar="),
+                                                                                "bar", List.of("bar=")));
+
+    // Value that contains multiple equals signs
+    assertEquals(QueryStringTools.parseQueryString("foo=bar="), Map.of("foo", List.of("bar=")));
+    assertEquals(QueryStringTools.parseQueryString("foo=bar=baz=&bar=foo=baz="), Map.of("foo", List.of("bar=baz="),
+                                                                                        "bar", List.of("foo=baz=")));
+  }
+}


### PR DESCRIPTION
Our query string parser was making an assumption that the value does not contain an un-escaped equals sign.

We should always be splitting on `=` and assuming the value is everything up until the next separator. If the `=` is just encoding padding, this won't be a problem because the trailing `=` is optional, but for any other value this could break. 