### PR TITLE
Cookie encryption requirement

### DIFF
--- a/prime-mvc.iml
+++ b/prime-mvc.iml
@@ -163,7 +163,7 @@
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13-sources.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/2.0.13/slf4j-api-2.0.13-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/main/java/org/primeframework/mvc/action/result/SavedRequestTools.java
+++ b/src/main/java/org/primeframework/mvc/action/result/SavedRequestTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2016-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,7 +146,13 @@ public class SavedRequestTools {
         value = value.substring("ready_".length());
       }
 
-      SavedHttpRequest savedRequest = CookieTools.fromJSONCookie(value, SavedHttpRequest.class, true, encryptor, objectMapper);
+      SavedHttpRequest savedRequest = CookieTools.fromJSONCookie(value,
+                                                                 SavedHttpRequest.class,
+                                                                 // we always encrypt in toCookie call
+                                                                 true,
+                                                                 true,
+                                                                 encryptor,
+                                                                 objectMapper);
       return new SaveHttpRequestResult(cookie, ready, savedRequest);
     } catch (Exception e) {
       logger.warn("Bad SavedRequest cookie [{}]. Error is [{}]", cookie.value, e.getMessage());

--- a/src/main/java/org/primeframework/mvc/message/scope/CookieFlashScope.java
+++ b/src/main/java/org/primeframework/mvc/message/scope/CookieFlashScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2019, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,7 +116,13 @@ public class CookieFlashScope implements FlashScope {
   private List<Message> deserialize(String s) {
     try {
       // @formatter:off
-      List<Message> messages = CookieTools.fromJSONCookie(s, new TypeReference<List<Message>>() {}, true, encryptor, objectMapper);
+      List<Message> messages = CookieTools.fromJSONCookie(s,
+                                                          new TypeReference<>() {},
+                                                          // requiring encryption on the 'from' side since we encrypt going to cookie
+                                                          true,
+                                                          true,
+                                                          encryptor,
+                                                          objectMapper);
       // @formatter:on
 
       if (messages == null) {

--- a/src/main/java/org/primeframework/mvc/scope/BaseBrowserSessionScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/BaseBrowserSessionScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ public abstract class BaseBrowserSessionScope<T extends Annotation> extends Abst
 
     boolean encrypt = encrypt(scope);
     try {
-      return CookieTools.fromJSONCookie(value, type, encrypt, encryptor, objectMapper);
+      return CookieTools.fromJSONCookie(value, type, encrypt, true, encryptor, objectMapper);
     } catch (Exception e) {
       String message = e.getClass().getCanonicalName() + " " + e.getMessage();
       if (encrypt) {

--- a/src/main/java/org/primeframework/mvc/scope/BaseManagedCookieScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/BaseManagedCookieScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,10 +114,10 @@ public abstract class BaseManagedCookieScope<T extends Annotation> extends Abstr
       ThrowingFunction<byte[], String> oldFunction = r -> objectMapper.readerFor(String.class).readValue(r);
       ThrowingFunction<byte[], String> newFunction = r -> new String(r, StandardCharsets.UTF_8);
       if (compress || encrypt) {
-        cookie.value = CookieTools.fromCookie(cookieValue, true, encryptor, oldFunction, newFunction);
+        cookie.value = CookieTools.fromCookie(cookieValue, encrypt, true, encryptor, oldFunction, newFunction);
       } else {
         try {
-          cookie.value = CookieTools.fromCookie(cookieValue, false, encryptor, oldFunction, newFunction);
+          cookie.value = CookieTools.fromCookie(cookieValue, encrypt, false, encryptor, oldFunction, newFunction);
         } catch (Throwable t) {
           // Smother because the cookie already has the value in it
         }

--- a/src/main/java/org/primeframework/mvc/scope/BaseManagedCookieScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/BaseManagedCookieScope.java
@@ -90,6 +90,8 @@ public abstract class BaseManagedCookieScope<T extends Annotation> extends Abstr
    */
   protected abstract boolean encrypt(T scope);
 
+  protected abstract boolean encryptionRequired(T scope);
+
   /**
    * Using the annotation, determines if the cookie is allowed to be null.
    *
@@ -102,6 +104,7 @@ public abstract class BaseManagedCookieScope<T extends Annotation> extends Abstr
   protected Cookie processCookie(Cookie cookie, String fieldName, Class<?> type, T scope) {
     boolean compress = compress(scope);
     boolean encrypt = encrypt(scope);
+    boolean encryptionRequired = encryptionRequired(scope);
     boolean neverNull = neverNull(scope);
 
     String cookieName = getCookieName(fieldName, scope);
@@ -114,10 +117,10 @@ public abstract class BaseManagedCookieScope<T extends Annotation> extends Abstr
       ThrowingFunction<byte[], String> oldFunction = r -> objectMapper.readerFor(String.class).readValue(r);
       ThrowingFunction<byte[], String> newFunction = r -> new String(r, StandardCharsets.UTF_8);
       if (compress || encrypt) {
-        cookie.value = CookieTools.fromCookie(cookieValue, encrypt, true, encryptor, oldFunction, newFunction);
+        cookie.value = CookieTools.fromCookie(cookieValue, encryptionRequired, true, encryptor, oldFunction, newFunction);
       } else {
         try {
-          cookie.value = CookieTools.fromCookie(cookieValue, encrypt, false, encryptor, oldFunction, newFunction);
+          cookie.value = CookieTools.fromCookie(cookieValue, encryptionRequired, false, encryptor, oldFunction, newFunction);
         } catch (Throwable t) {
           // Smother because the cookie already has the value in it
         }

--- a/src/main/java/org/primeframework/mvc/scope/BrowserActionSessionScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/BrowserActionSessionScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ public class BrowserActionSessionScope extends BaseBrowserSessionScope<BrowserAc
     try {
       Encryptor encryptor = injector.getInstance(Encryptor.class);
       ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
-      return CookieTools.fromJSONCookie(value, type, encrypted, encryptor, objectMapper);
+      return CookieTools.fromJSONCookie(value, type, encrypted, true, encryptor, objectMapper);
     } catch (Exception e) {
       String message = e.getClass().getCanonicalName() + " " + e.getMessage();
       if (scope.encrypt()) {
@@ -128,7 +128,7 @@ public class BrowserActionSessionScope extends BaseBrowserSessionScope<BrowserAc
       ActionInvocation ai = actionInvocationStore.getCurrent();
       if (ai.action == null) {
         throw new PrimeException("Attempting to store a value in the action session but the current request URL isn'" +
-            "t associated with an action class");
+                                 "t associated with an action class");
       }
       className = ai.action.getClass().getName();
     }

--- a/src/main/java/org/primeframework/mvc/scope/ManagedCookieScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/ManagedCookieScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,11 @@ public class ManagedCookieScope extends BaseManagedCookieScope<ManagedCookie> {
   @Override
   protected boolean encrypt(ManagedCookie scope) {
     return scope.encrypt();
+  }
+
+  @Override
+  protected boolean encryptionRequired(ManagedCookie scope) {
+    return scope.encryptionRequired();
   }
 
   @Override

--- a/src/main/java/org/primeframework/mvc/scope/ManagedSessionCookieScope.java
+++ b/src/main/java/org/primeframework/mvc/scope/ManagedSessionCookieScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,11 @@ public class ManagedSessionCookieScope extends BaseManagedCookieScope<ManagedSes
   @Override
   protected boolean encrypt(ManagedSessionCookie scope) {
     return scope.encrypt();
+  }
+
+  @Override
+  protected boolean encryptionRequired(ManagedSessionCookie scope) {
+    return scope.encryptionRequired();
   }
 
   @Override

--- a/src/main/java/org/primeframework/mvc/scope/annotation/ManagedCookie.java
+++ b/src/main/java/org/primeframework/mvc/scope/annotation/ManagedCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,14 @@ public @interface ManagedCookie {
    * @return true if the cookie value should be encrypted.
    */
   boolean encrypt() default true;
+
+  /**
+   * By default, if an unencrypted cookie is presented by the browser, that cookie will not be used.
+   * Setting this to false is dangerous.
+   *
+   * @return true if encryption is required, false if not
+   */
+  boolean encryptionRequired() default true;
 
   /**
    * Optionally specify a value to set on the cookie for Max-Age. Defaults to 70 years because Firefox has issues with

--- a/src/main/java/org/primeframework/mvc/scope/annotation/ManagedSessionCookie.java
+++ b/src/main/java/org/primeframework/mvc/scope/annotation/ManagedSessionCookie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,14 @@ public @interface ManagedSessionCookie {
    * @return true if the cookie value should be encrypted.
    */
   boolean encrypt() default true;
+
+  /**
+   * By default, if an unencrypted cookie is presented by the browser, that cookie will not be used.
+   * Setting this to false is dangerous.
+   *
+   * @return true if encryption is required, false if not
+   */
+  boolean encryptionRequired() default true;
 
   /**
    * @return This attribute determines the name under which that the value is stored in the action session. The default

--- a/src/main/java/org/primeframework/mvc/security/BaseUserIdCookieSecurityContext.java
+++ b/src/main/java/org/primeframework/mvc/security/BaseUserIdCookieSecurityContext.java
@@ -223,7 +223,13 @@ public abstract class BaseUserIdCookieSecurityContext<TUserId> implements UserLo
       return null;
     }
     try {
-      context = CookieTools.fromJSONCookie(cookie, getUserIdSessionContextClass(), true, encryptor, objectMapper);
+      context = CookieTools.fromJSONCookie(cookie,
+                                           getUserIdSessionContextClass(),
+                                           // we always encrypt in toCookie call
+                                           true,
+                                           true,
+                                           encryptor,
+                                           objectMapper);
       var shouldExtend = shouldExtendCookie(context.getLoginInstant());
       switch (shouldExtend) {
         case Extend:

--- a/src/main/java/org/primeframework/mvc/security/BaseUserIdCookieSecurityContext.java
+++ b/src/main/java/org/primeframework/mvc/security/BaseUserIdCookieSecurityContext.java
@@ -27,6 +27,8 @@ import io.fusionauth.http.server.HTTPRequest;
 import io.fusionauth.http.server.HTTPResponse;
 import org.primeframework.mvc.ErrorException;
 import org.primeframework.mvc.util.CookieTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Logs in and out users based on storing their User ID in a cookie and also adds a sliding session
@@ -38,6 +40,8 @@ public abstract class BaseUserIdCookieSecurityContext<TUserId> implements UserLo
   public static final String UserKey = "primeCurrentUser";
 
   private static final String ContextKey = "primeLoginContext";
+
+  private static final Logger logger = LoggerFactory.getLogger(BaseUserIdCookieSecurityContext.class);
 
   protected final CookieProxy sessionCookie;
 
@@ -244,12 +248,16 @@ public abstract class BaseUserIdCookieSecurityContext<TUserId> implements UserLo
       this.request.setAttribute(ContextKey, context);
       return context;
     } catch (BadPaddingException e) {
+      logger.debug("User cookie parsing failed. It is likely the cookie encryption key has changed, deleting session",
+                   e);
       // if the cookie encryption key changes (DB change, etc.) then we need new cookies, otherwise we cannot
       // decrypt and a user will be stuck trying to get back in
       this.deleteCookies();
       return null;
     } catch (Exception e) {
-      throw new ErrorException(e);
+      logger.debug("User cookie parsing failed because decoding or decryption failed, deleting session", e);
+      this.deleteCookies();
+      return null;
     }
   }
 

--- a/src/main/java/org/primeframework/mvc/security/csrf/DefaultEncryptionBasedTokenCSRFProvider.java
+++ b/src/main/java/org/primeframework/mvc/security/csrf/DefaultEncryptionBasedTokenCSRFProvider.java
@@ -102,7 +102,8 @@ public class DefaultEncryptionBasedTokenCSRFProvider implements CSRFProvider {
 
   private CSRFToken decrypt(String s) {
     try {
-      return CookieTools.fromJSONCookie(s, CSRFToken.class, true, encryptor, objectMapper);
+      // we encrypt going to cookie, so requiring going from
+      return CookieTools.fromJSONCookie(s, CSRFToken.class, true, true, encryptor, objectMapper);
     } catch (Exception e) {
       return null;
     }

--- a/src/main/java/org/primeframework/mvc/util/CookieTools.java
+++ b/src/main/java/org/primeframework/mvc/util/CookieTools.java
@@ -71,7 +71,9 @@ public final class CookieTools {
     boolean compress = (result[3] & 0x02) == 0x02; // Second bit is compressed
     result = Arrays.copyOfRange(result, 4, result.length);
 
-    if (encrypt) {
+    if (encryptionRequired && !encrypt) {
+      throw new EncryptionException("Encryption is required to decrypt cookie but a non-encrypted cookie was presented");
+    } else if (encrypt) {
       result = encryptor.decrypt(result);
     }
 
@@ -85,13 +87,14 @@ public final class CookieTools {
   /**
    * Processes a cookie value and converts it to an object.
    *
-   * @param value          The cookie value.
-   * @param type           The type of object to convert to.
-   * @param encryptedIfOld If the cookie header indicates it is an older cookie, then we only decrypt it if this is
-   *                       true.
-   * @param encryptor      The encryptor to use for decrypting the cookie.
-   * @param objectMapper   The ObjectMapper used to convert from JSON to an object.
-   * @param <T>            The type to convert to.
+   * @param value              The cookie value.
+   * @param type               The type of object to convert to.
+   * @param encryptionRequired Whether encryption is required or not
+   * @param encryptedIfOld     If the cookie header indicates it is an older cookie, then we only decrypt it if this is
+   *                           true.
+   * @param encryptor          The encryptor to use for decrypting the cookie.
+   * @param objectMapper       The ObjectMapper used to convert from JSON to an object.
+   * @param <T>                The type to convert to.
    * @return The object or null if the cookie couldn't be converted.
    * @throws Exception If the operation fails.
    */
@@ -105,13 +108,14 @@ public final class CookieTools {
   /**
    * Processes a cookie value and converts it to an object.
    *
-   * @param value          The cookie value.
-   * @param type           The type of object to convert to.
-   * @param encryptedIfOld If the cookie header indicates it is an older cookie, then we only decrypt it if this is
-   *                       true.
-   * @param encryptor      The encryptor to use for decrypting the cookie.
-   * @param objectMapper   The ObjectMapper used to convert from JSON to an object.
-   * @param <T>            The type to convert to.
+   * @param value              The cookie value.
+   * @param type               The type of object to convert to.
+   * @param encryptionRequired Whether encryption is required or not
+   * @param encryptedIfOld     If the cookie header indicates it is an older cookie, then we only decrypt it if this is
+   *                           true.
+   * @param encryptor          The encryptor to use for decrypting the cookie.
+   * @param objectMapper       The ObjectMapper used to convert from JSON to an object.
+   * @param <T>                The type to convert to.
    * @return The object or null if the cookie couldn't be converted.
    * @throws Exception If the operation fails.
    */

--- a/src/main/java/org/primeframework/mvc/util/CookieTools.java
+++ b/src/main/java/org/primeframework/mvc/util/CookieTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2022-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,16 +31,17 @@ public final class CookieTools {
   /**
    * Processes a cookie value and calls a Function to convert it to a meaningful value for the application (or Prime).
    *
-   * @param value          The cookie value.
-   * @param encryptedIfOld Whether a legacy cookie was likely encrypted or not.
-   * @param encryptor      The encryptor to use if needed.
-   * @param oldFunction    The function to call if the cookie looks legacy.
-   * @param newFunction    The function to call if the cookie looks new (contains our magic header).
-   * @param <T>            The type that the function returns.
+   * @param value              The cookie value.
+   * @param encryptionRequired Whether encryption is required or not
+   * @param encryptedIfOld     Whether a legacy cookie was likely encrypted or not.
+   * @param encryptor          The encryptor to use if needed.
+   * @param oldFunction        The function to call if the cookie looks legacy.
+   * @param newFunction        The function to call if the cookie looks new (contains our magic header).
+   * @param <T>                The type that the function returns.
    * @return The value or null if the cookie is empty.
    * @throws Exception If the operation fails.
    */
-  public static <T> T fromCookie(String value, boolean encryptedIfOld, Encryptor encryptor,
+  public static <T> T fromCookie(String value, boolean encryptionRequired, boolean encryptedIfOld, Encryptor encryptor,
                                  ThrowingFunction<byte[], T> oldFunction, ThrowingFunction<byte[], T> newFunction)
       throws Exception {
     if (value == null || value.isBlank()) {
@@ -94,10 +95,11 @@ public final class CookieTools {
    * @return The object or null if the cookie couldn't be converted.
    * @throws Exception If the operation fails.
    */
-  public static <T> T fromJSONCookie(String value, TypeReference<T> type, boolean encryptedIfOld, Encryptor encryptor,
+  public static <T> T fromJSONCookie(String value, TypeReference<T> type, boolean encryptionRequired,
+                                     boolean encryptedIfOld, Encryptor encryptor,
                                      ObjectMapper objectMapper) throws Exception {
     ThrowingFunction<byte[], T> read = r -> objectMapper.readerFor(type).readValue(r);
-    return fromCookie(value, encryptedIfOld, encryptor, read, read);
+    return fromCookie(value, encryptionRequired, encryptedIfOld, encryptor, read, read);
   }
 
   /**
@@ -113,10 +115,10 @@ public final class CookieTools {
    * @return The object or null if the cookie couldn't be converted.
    * @throws Exception If the operation fails.
    */
-  public static <T> T fromJSONCookie(String value, Class<T> type, boolean encryptedIfOld, Encryptor encryptor,
+  public static <T> T fromJSONCookie(String value, Class<T> type, boolean encryptionRequired, boolean encryptedIfOld, Encryptor encryptor,
                                      ObjectMapper objectMapper) throws Exception {
     ThrowingFunction<byte[], T> read = r -> objectMapper.readerFor(type).readValue(r);
-    return fromCookie(value, encryptedIfOld, encryptor, read, read);
+    return fromCookie(value, encryptionRequired, encryptedIfOld, encryptor, read, read);
   }
 
   /**

--- a/src/main/java/org/primeframework/mvc/util/EncryptionException.java
+++ b/src/main/java/org/primeframework/mvc/util/EncryptionException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.util;
+
+/**
+ * Indicates a problem during cookie encryption/decryption
+ */
+public class EncryptionException extends RuntimeException {
+  public EncryptionException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/org/example/action/LegacyManagedCookieAction.java
+++ b/src/test/java/org/example/action/LegacyManagedCookieAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,11 @@ import org.primeframework.mvc.scope.annotation.ManagedCookie;
  */
 @Action
 public class LegacyManagedCookieAction {
-  @ManagedCookie
+  // since CompressedManagedCookieAction sets encrypt to false, the 2nd HTTP request of
+  // ManagedCookieTest.compressed_only_cookie, which is a POST, sets an unencrypted
+  // cookie value. the get to this action which follows should be able to read it if
+  // and ONLY if encryptionRequired is set to false here
+  @ManagedCookie(encryptionRequired = false)
   public Cookie cookie;
 
   public String value;

--- a/src/test/java/org/example/action/browserSession/DecryptedAction.java
+++ b/src/test/java/org/example/action/browserSession/DecryptedAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.example.action.browserSession;
+
+import org.example.domain.User;
+import org.primeframework.mvc.action.annotation.Action;
+import org.primeframework.mvc.action.result.annotation.Redirect;
+import org.primeframework.mvc.scope.annotation.BrowserSession;
+
+@Action
+@Redirect(code = "next", uri = "/browser-session/second")
+public class DecryptedAction {
+  // idea is to have this action serialize user to a decrypted cookie
+  // and then attempt to decrypt using SecondAction
+  @BrowserSession(encrypt = false)
+  public User user;
+
+  public String get() {
+    user = new User();
+    user.setName("Brian Pontarelli");
+    return "next";
+  }
+}

--- a/src/test/java/org/example/action/browserSession/DecryptedAction.java
+++ b/src/test/java/org/example/action/browserSession/DecryptedAction.java
@@ -24,7 +24,8 @@ import org.primeframework.mvc.scope.annotation.BrowserSession;
 @Redirect(code = "next", uri = "/browser-session/second")
 public class DecryptedAction {
   // idea is to have this action serialize user to a decrypted cookie
-  // and then attempt to decrypt using SecondAction
+  // and then attempt to decrypt using SecondAction, which
+  // requires an encrypted cookie
   @BrowserSession(encrypt = false)
   public User user;
 

--- a/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
+++ b/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2020, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,24 @@ import org.testng.annotations.Test;
  * @author Brian Pontarelli
  */
 public class BrowserSessionTest extends PrimeBaseTest {
+  @Test
+  public void not_encrypted_cookie() throws Exception {
+    test.simulate(() -> simulator.test("/browser-session/decrypted")
+                                 .get()
+                                 .assertStatusCode(302)
+                                 .assertRedirect("/browser-session/second")
+                                 .assertContainsCookie("user"))
+        .simulate(() -> simulator.test("/browser-session/second")
+                                 .get()
+                                 .assertStatusCode(200)
+                                 // decrypted tries to use a non-encrypted cookie
+                                 // to supply a user to SecondAction, which
+                                 // requires an encrypted cookie by virtue of
+                                 // relying on the defaults for @BrowserSession
+                                 .assertBodyContains("The user is missing")
+                                 .assertDoesNotContainsCookie("user"));
+  }
+
   @Test
   public void sessionCookie() throws Exception {
     test.simulate(() -> simulator.test("/browser-session/first")

--- a/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
+++ b/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
@@ -38,7 +38,7 @@ public class BrowserSessionTest extends PrimeBaseTest {
                                  // requires an encrypted cookie by virtue of
                                  // relying on the defaults for @BrowserSession
                                  .assertBodyContains("The user is missing")
-                                 .assertDoesNotContainsCookie("user"));
+                                 .assertCookieWasDeleted("user"));
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
+++ b/src/test/java/org/primeframework/mvc/action/result/SaveRequestResultTest.java
@@ -87,7 +87,12 @@ public class SaveRequestResultTest extends PrimeBaseTest {
     result.execute(annotation);
 
     // The cookie value will be different each time because the initialization vector is unique per request. Decrypt the actual value to compare it to the expected.
-    SavedHttpRequest actual = CookieTools.fromJSONCookie(response.getCookies().get(0).value, SavedHttpRequest.class, true, encryptor, objectMapper);
+    SavedHttpRequest actual = CookieTools.fromJSONCookie(response.getCookies().get(0).value,
+                                                         SavedHttpRequest.class,
+                                                         true,
+                                                         true,
+                                                         encryptor,
+                                                         objectMapper);
     SavedHttpRequest expected = new SavedHttpRequest(HTTPMethod.GET, "/test?param1=value1&param2=value2", null);
     assertEquals(actual, expected);
 
@@ -119,7 +124,12 @@ public class SaveRequestResultTest extends PrimeBaseTest {
 
     if (allowPost && origin.equals(request.getBaseURL())) {
       // The cookie value will be different each time because the initialization vector is unique per request. Decrypt the actual value to compare it to the expected.
-      SavedHttpRequest actual = CookieTools.fromJSONCookie(response.getCookies().get(0).value, SavedHttpRequest.class, true, encryptor, objectMapper);
+      SavedHttpRequest actual = CookieTools.fromJSONCookie(response.getCookies().get(0).value,
+                                                           SavedHttpRequest.class,
+                                                           true,
+                                                           true,
+                                                           encryptor,
+                                                           objectMapper);
       SavedHttpRequest expected = new SavedHttpRequest(HTTPMethod.POST, "/test", request.getParameters());
       assertEquals(actual, expected);
     } else {

--- a/src/test/java/org/primeframework/mvc/security/SessionCookieKeyChanger.java
+++ b/src/test/java/org/primeframework/mvc/security/SessionCookieKeyChanger.java
@@ -42,7 +42,12 @@ public class SessionCookieKeyChanger {
    */
   public void changeIt(Cookie cookie) {
     try {
-      UserIdSessionContext existingContainer = CookieTools.fromJSONCookie(cookie.value, MockUserIdSessionContext.class, true, encryptor, objectMapper);
+      UserIdSessionContext existingContainer = CookieTools.fromJSONCookie(cookie.value,
+                                                                          MockUserIdSessionContext.class,
+                                                                          true,
+                                                                          true,
+                                                                          encryptor,
+                                                                          objectMapper);
       byte[] result = objectMapper.writeValueAsBytes(existingContainer);
       var config = new MockConfiguration();
       config.regenerateCookieEncryptionKey();

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -804,7 +804,7 @@ public class RequestResult {
     ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
     ThrowingFunction<byte[], String> oldFunction = r -> objectMapper.readerFor(String.class).readValue(r);
     ThrowingFunction<byte[], String> newFunction = r -> new String(r, StandardCharsets.UTF_8);
-    actual.value = CookieTools.fromCookie(actual.value, true, encryptor, oldFunction, newFunction);
+    actual.value = CookieTools.fromCookie(actual.value, true, true, encryptor, oldFunction, newFunction);
     if (consumer != null) {
       consumer.accept(actual);
     }
@@ -826,7 +826,7 @@ public class RequestResult {
     ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
     ThrowingFunction<byte[], String> oldFunction = r -> objectMapper.readerFor(String.class).readValue(r);
     ThrowingFunction<byte[], String> newFunction = r -> new String(r, StandardCharsets.UTF_8);
-    String actualDecrypted = CookieTools.fromCookie(actual.value, true, encryptor, oldFunction, newFunction);
+    String actualDecrypted = CookieTools.fromCookie(actual.value, true, true, encryptor, oldFunction, newFunction);
     if (!Objects.equals(value, actualDecrypted)) {
       throw new AssertionError("Cookie [" + name + "] with decrypted value [" + actualDecrypted + "] was not equal to the expected value [" + value + "]"
                                + "\nActual cookie:\n"


### PR DESCRIPTION
* Add a new boolean to `CookieTools` that allows requiring encryption when parsing cookies.
* Change Saved Requests, Cookie Flash, Browser Session, CSRF Tokens, and Browser Action Session to always require encrypted cookies.
* Allow Managed Cookies to decide for themselves, but make encryption requirement the default.
* Replicated original problem in `BrowserSessionTest` first.