### PR TITLE
Allow configuration to enable or disable alternate actions URI

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.4.14"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.26.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.27.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.26.1</version>
+  <version>4.27.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/prime-mvc.ipr
+++ b/prime-mvc.ipr
@@ -105,6 +105,7 @@
       <inspection_tool class="SizeReplaceableByIsEmpty" enabled="true" level="WARNING" enabled_by_default="true">
         <option name="ignoredTypes">
           <set>
+            <option value="java.lang.String" />
             <option value="java.util.List" />
           </set>
         </option>
@@ -544,7 +545,7 @@
           <fileSet type="namedScope" name="control-templates" pattern="file[prime-mvc]:src/main/ftl/WEB-INF/control-templates/*" />
         </list>
       </option>
-      <DB2CodeStyleSettings version="6">
+      <DB2CodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -584,7 +585,7 @@
         <option name="EXPR_CASE_THEN_WRAP" value="true" />
         <option name="PRIMARY_KEY_NAME_TEMPLATE" value="{table}_{columns}_pk" />
       </DB2CodeStyleSettings>
-      <DerbyCodeStyleSettings version="6">
+      <DerbyCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -628,7 +629,7 @@
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
       </GroovyCodeStyleSettings>
-      <H2CodeStyleSettings version="6">
+      <H2CodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -668,7 +669,7 @@
         <option name="EXPR_CASE_THEN_WRAP" value="true" />
         <option name="PRIMARY_KEY_NAME_TEMPLATE" value="{table}_{columns}_pk" />
       </H2CodeStyleSettings>
-      <HSQLCodeStyleSettings version="6">
+      <HSQLCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -732,7 +733,7 @@
         <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
         <option name="JD_INDENT_ON_CONTINUATION" value="true" />
       </JavaCodeStyleSettings>
-      <MSSQLCodeStyleSettings version="6">
+      <MSSQLCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -775,7 +776,7 @@
       <MarkdownNavigatorCodeStyleSettings>
         <option name="WRAP_ON_TYPING" value="0" />
       </MarkdownNavigatorCodeStyleSettings>
-      <MySQLCodeStyleSettings version="6">
+      <MySQLCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -815,7 +816,7 @@
         <option name="EXPR_CASE_THEN_WRAP" value="true" />
         <option name="PRIMARY_KEY_NAME_TEMPLATE" value="{table}_{columns}_pk" />
       </MySQLCodeStyleSettings>
-      <OracleCodeStyleSettings version="6">
+      <OracleCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -861,7 +862,7 @@
         <option name="PHPDOC_BLANK_LINES_AROUND_PARAMETERS" value="true" />
         <option name="PHPDOC_WRAP_LONG_LINES" value="true" />
       </PHPCodeStyleSettings>
-      <PostgresCodeStyleSettings version="6">
+      <PostgresCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -904,7 +905,7 @@
       <Properties>
         <option name="KEEP_BLANK_LINES" value="true" />
       </Properties>
-      <SQLiteCodeStyleSettings version="6">
+      <SQLiteCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -947,7 +948,7 @@
       <ScalaCodeStyleSettings>
         <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
       </ScalaCodeStyleSettings>
-      <SqlCodeStyleSettings version="6">
+      <SqlCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />
@@ -1012,7 +1013,7 @@
         <option name="WRAP_PARENTHESIZED_EXPRESSION_INSIDE_VALUES" value="0" />
         <option name="NEW_LINE_AFTER_SELECT_ITEM" value="false" />
       </SqlCodeStyleSettings>
-      <SybaseCodeStyleSettings version="6">
+      <SybaseCodeStyleSettings version="7">
         <option name="KEYWORD_CASE" value="2" />
         <option name="TYPE_CASE" value="2" />
         <option name="CUSTOM_TYPE_CASE" value="2" />

--- a/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/AbstractMVCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ public abstract class AbstractMVCConfiguration implements MVCConfiguration {
 
   public static final long MAX_SIZE = 1024000;
 
+  public boolean allowActionParameterDuringActionMappingWorkflow = true;
+
   public boolean autoHTMLEscapingEnabled = true;
 
   public String controlTemplateDirectory = "control-templates";
@@ -75,6 +77,11 @@ public abstract class AbstractMVCConfiguration implements MVCConfiguration {
   public String templateDirectory = "templates";
 
   public List<Class<? extends Annotation>> unwrapAnnotations = Collections.singletonList(FieldUnwrapped.class);
+
+  @Override
+  public boolean allowActionParameterDuringActionMappingWorkflow() {
+    return allowActionParameterDuringActionMappingWorkflow;
+  }
 
   @Override
   public boolean autoHTMLEscapingEnabled() {

--- a/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/config/MVCConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2024, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import io.fusionauth.http.Cookie.SameSite;
+import org.primeframework.mvc.parameter.DefaultParameterParser;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 
 /**
@@ -31,6 +32,13 @@ import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
  * @author Brian Pontarelli
  */
 public interface MVCConfiguration {
+  /**
+   * In most cases you should disable this feature. While it may be useful, modifying the URI may have un-intended consequences.
+   *
+   * @return true if alternate actions can be specified by using the {@link DefaultParameterParser#ACTION_PREFIX} prefix.
+   */
+  boolean allowActionParameterDuringActionMappingWorkflow();
+
   /**
    * @return true if unknown parameters should be allowed, false if they are not allowed.
    */
@@ -135,7 +143,7 @@ public interface MVCConfiguration {
 
   /**
    * @return The number of seconds to check for Freemarker template updates (max integer means never and 0 means
-   * always).
+   *     always).
    */
   int templateCheckSeconds();
 
@@ -146,7 +154,7 @@ public interface MVCConfiguration {
 
   /**
    * @return The annotations that identify a field to be un-wrapped - or be considered transparent by the
-   * {@link ExpressionEvaluator}.
+   *     {@link ExpressionEvaluator}.
    */
   List<Class<? extends Annotation>> unwrapAnnotations();
 }

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -77,6 +77,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.FileAssert.fail;
 
 /**
@@ -1174,6 +1175,31 @@ public class GlobalTest extends PrimeBaseTest {
                                      "foo.bar => [baz]",
                                      "foo/0/bar/bam => [purple]"
                                  ));
+  }
+
+  @Test
+  public void get_url_rewrite() {
+    simulator.test("/doesNotExist?__a_foo=/user/edit&foo=true")
+             .get()
+             .assertStatusCode(200)
+             .assertContainsNoFieldMessages()
+             .assertBodyContains("""
+                                     <head><title>Edit a user</title></head>
+                                     """);
+    assertTrue(EditAction.getCalled);
+
+    // Disabled
+    configuration.allowActionParameterDuringActionMappingWorkflow = false;
+
+    // Reset
+    EditAction.getCalled = false;
+
+    simulator.test("/doesNotExist?__a_foo=/user/edit&foo=true")
+             .get()
+             .assertStatusCode(404)
+             .assertContainsNoFieldMessages()
+             .assertBodyContains("The page is missing!");
+    assertFalse(EditAction.getCalled);
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -202,12 +202,18 @@ public abstract class PrimeBaseTest {
     // Reset allowUnknownParameters
     configuration.allowUnknownParameters = false;
 
+    // Reset to default
+    configuration.allowActionParameterDuringActionMappingWorkflow = true;
+
     // Reset the call count on the invocation finalizer
     MockMVCWorkflowFinalizer.Called.set(0);
 
     // Reset accumulating logger, using TRACE for now to debug some tests
     ((TestAccumulatingLogger) TestAccumulatingLoggerFactory.FACTORY.getLogger(PrimeBaseTest.class)).reset();
     TestAccumulatingLoggerFactory.FACTORY.getLogger(PrimeBaseTest.class).setLevel(Level.Trace);
+
+    // Reset
+    EditAction.getCalled = false;
 
     TestUnhandledExceptionHandler.reset();
   }

--- a/src/test/java/org/primeframework/mvc/action/DefaultActionMappingWorkflowTest.java
+++ b/src/test/java/org/primeframework/mvc/action/DefaultActionMappingWorkflowTest.java
@@ -54,7 +54,7 @@ public class DefaultActionMappingWorkflowTest extends PrimeBaseTest {
 
   @Test
   public void differentButtonClick_notAllowed() throws Exception {
-    // Default behavior will be to limit using alternate form actions
+    // Disable action mapping using action parameter __a_
     configuration.allowActionParameterDuringActionMappingWorkflow = false;
 
     request.setPath("/admin/user/edit");

--- a/src/test/java/org/primeframework/mvc/action/DefaultActionMappingWorkflowTest.java
+++ b/src/test/java/org/primeframework/mvc/action/DefaultActionMappingWorkflowTest.java
@@ -53,7 +53,24 @@ public class DefaultActionMappingWorkflowTest extends PrimeBaseTest {
   }
 
   @Test
+  public void differentButtonClick_notAllowed() throws Exception {
+    // Default behavior will be to limit using alternate form actions
+    configuration.allowActionParameterDuringActionMappingWorkflow = false;
+
+    request.setPath("/admin/user/edit");
+    request.setMethod(HTTPMethod.POST);
+    request.addURLParameter("__a_submit", "");
+    request.addURLParameter("__a_cancel", "/admin/user/cancel");
+    request.addURLParameter("cancel", "Cancel");
+
+    run("/admin/user/edit", "/admin/user/edit", null);
+  }
+
+  @Test
   public void differentButtonClickRelativeURI() throws Exception {
+    // enable alternate form actions
+    configuration.allowActionParameterDuringActionMappingWorkflow = true;
+
     request.setPath("/admin/user/edit");
     request.setMethod(HTTPMethod.POST);
     request.addURLParameter("__a_submit", "");
@@ -126,7 +143,7 @@ public class DefaultActionMappingWorkflowTest extends PrimeBaseTest {
     chain.continueWorkflow();
     EasyMock.replay(chain);
 
-    DefaultActionMappingWorkflow workflow = new DefaultActionMappingWorkflow(request, response, store, new DefaultActionMapper(provider, injector));
+    DefaultActionMappingWorkflow workflow = new DefaultActionMappingWorkflow(request, response, store, new DefaultActionMapper(provider, injector), configuration);
     workflow.perform(chain);
 
     ActionInvocation ai = capture.getValue();


### PR DESCRIPTION
Allow configuration to enable or disable alternate actions URI via parameter.

This is one way to allow this behavior to be modified. We could also consider removing this feature, since there are other ways to handle this, or perhaps we allow it but pass the return to the beginning of the MVC workflow to ensure we re-execute andy workflow steps prior to this modification. 

This will be removed in the next major version which will be on the Java 21 Virtual Threads branch. 
- https://github.com/prime-framework/prime-mvc/pull/65