### PR TITLE
Reduce noise from fuzzing, or various unexpected inputs

### DIFF
--- a/src/main/java/org/primeframework/mvc/message/l10n/ResourceBundleMessageProvider.java
+++ b/src/main/java/org/primeframework/mvc/message/l10n/ResourceBundleMessageProvider.java
@@ -79,7 +79,8 @@ public class ResourceBundleMessageProvider implements MessageProvider {
     String message = getOptionalMessage(key, values);
     if (message == null) {
       ActionInvocation actionInvocation = invocationStore.getCurrent();
-      throw new MissingMessageException("Message could not be found for the URI [" + actionInvocation.actionURI + "] and key [" + key + "]");
+      String uri = actionInvocation != null ? actionInvocation.actionURI : null;
+      throw new MissingMessageException("Message could not be found for the URI [" + uri + "] and key [" + key + "]");
     }
 
     return message;
@@ -96,7 +97,8 @@ public class ResourceBundleMessageProvider implements MessageProvider {
 
     if (template == null) {
       if (!"[ValidationException]".equals(key)) {
-        logger.debug("Message could not be found for the URI [{}] and key [{}]", actionInvocation.actionURI, key);
+        String uri = actionInvocation != null ? actionInvocation.actionURI : null;
+        logger.debug("Message could not be found for the URI [{}] and key [{}]", uri, key);
       }
 
       return null;
@@ -131,12 +133,13 @@ public class ResourceBundleMessageProvider implements MessageProvider {
    * @return The message or null if it doesn't exist.
    */
   protected String findMessage(ActionInvocation actionInvocation, String key) {
-    String message = findMessage(actionInvocation.actionURI, key);
+    String actionURI = actionInvocation != null ? actionInvocation.actionURI : "/";
+    String message = findMessage(actionURI, key);
     if (message != null) {
       return message;
     }
 
-    ActionConfiguration config = actionInvocation.configuration;
+    ActionConfiguration config = actionInvocation != null ? actionInvocation.configuration : null;
     if (config == null) {
       return null;
     }

--- a/src/test/java/messages/package.properties
+++ b/src/test/java/messages/package.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2001-2007, Inversoft Inc., All Rights Reserved
+# Copyright (c) 2001-2025, Inversoft Inc., All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,3 +15,6 @@
 #
 key=Super Package Message
 format_key=Super Package Message %s %s %s
+
+# Default messages
+[blank]=Required

--- a/src/test/java/org/primeframework/mvc/message/l10n/ResourceBundleMessageProviderTest.java
+++ b/src/test/java/org/primeframework/mvc/message/l10n/ResourceBundleMessageProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2001-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,31 @@ public class ResourceBundleMessageProviderTest extends PrimeBaseTest {
     ResourceBundleMessageProvider provider = new ResourceBundleMessageProvider(localeProvider, new WebControl(new ServletContainerResolver(context), configuration), store);
     try {
       provider.getMessage("bad_key");
+      fail("Should have failed");
+    } catch (MissingMessageException e) {
+      // Expected
+    }
+
+    verify(store);
+  }
+
+  @Test
+  public void noActionInvocation() {
+    HTTPContext context = new HTTPContext(Path.of("src/test/java"));
+    ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);
+    expect(store.getCurrent()).andReturn(null).times(3);
+    replay(store);
+
+    LocaleProvider localeProvider = createStrictMock(LocaleProvider.class);
+    expect(localeProvider.get()).andReturn(Locale.US).anyTimes();
+    replay(localeProvider);
+
+    ResourceBundleMessageProvider provider = new ResourceBundleMessageProvider(localeProvider, new WebControl(new ServletContainerResolver(context), configuration), store);
+    assertEquals(provider.getMessage("[blank]foo.bar"), "Required");
+
+    // Really missing
+    try {
+      provider.getMessage("[not_found]bar");
       fail("Should have failed");
     } catch (MissingMessageException e) {
       // Expected

--- a/src/test/web/messages/package.properties
+++ b/src/test/web/messages/package.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2001-2022, Inversoft Inc., All Rights Reserved
+# Copyright (c) 2001-2025, Inversoft Inc., All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,3 +23,6 @@ format_key=Super Package Message %s %s %s
 [UnsupportedContentType]=Unsupported [Content-Type] HTTP request header value of [%s].
 
 [invalidJSON]=Unable to parse JSON. The property [%s] was invalid. The error was [%s]. The detailed exception was [%s].
+
+# Default messages
+[blank]=Required


### PR DESCRIPTION
Reduce noise from fuzzing, or various unexpected inputs that may cause message lookup to fail when no action invocation exists.

Fixes https://github.com/prime-framework/prime-mvc/issues/67