### PR TITLE
build a new MockUserAgent on every reset request

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.4.14"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.29.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.29.2", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.29.1</version>
+  <version>4.29.2</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/test/java/org/primeframework/mvc/test/RequestSimulator.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestSimulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,6 @@ public class RequestSimulator {
 
   public final TestPrimeMainThread thread;
 
-  public final MockUserAgent userAgent;
-
   public int actualPort = -1;
 
   public int port;
@@ -43,6 +41,8 @@ public class RequestSimulator {
   public int tlsPort;
 
   public boolean useTLS;
+
+  public MockUserAgent userAgent;
 
   /**
    * Creates a new request simulator that can be used to simulate requests to a Prime application.
@@ -112,7 +112,7 @@ public class RequestSimulator {
 
   public void reset() {
     actualPort = -1;
-    userAgent.clearAllCookies();
+    userAgent = new MockUserAgent();
     useTLS = false;
   }
 


### PR DESCRIPTION
Instead of trying to reset, just build a new Mock UserAgent. The hope is that helps with some intermittent failures due to some async tests running in test suites with thousands of tests.

The theory is that a test may start up a thread in some cases and do work which will be using a `RequestBuilder` that has a reference to the `MockUserAgent`. So if it does anything with cookies, it could hose up the next running test. Before each test we call `reset()` which clears the collection of cookies, but it still assumes nobody else is touching it. By building a new one for each actual test using `beforeMethod()` I think this will be safer. 