### PR TITLE
revert a change to assertBodyFile.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.1.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.1.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -684,7 +684,7 @@ public class GlobalTest extends PrimeBaseTest {
   public void get_fullFormWithAllAttributes() throws Exception {
     simulator.test("/user/full-form")
              .get()
-             .assertBodyFile(Path.of("src/test/resources/html/full-form.html"));
+             .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
   }
 
   @Test
@@ -889,7 +889,7 @@ public class GlobalTest extends PrimeBaseTest {
   public void get_metrics() throws Exception {
     simulator.test("/user/full-form")
              .get()
-             .assertBodyFile(Path.of("src/test/resources/html/full-form.html"));
+             .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
 
     Map<String, Timer> timers = metricRegistry.getTimers();
     assertEquals(timers.get("prime-mvc.[/user/full-form].requests").getCount(), 1);

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -384,8 +384,7 @@ public class RequestResult {
    */
   public RequestResult assertBodyFile(Path path, Object... values) throws IOException {
     if (values.length == 0) {
-      var body = Files.readString(path).trim();
-      return assertBody(body);
+      return assertBody(Files.readString(path));
     }
     return assertBody(BodyTools.processTemplateForAssertion(path, values));
   }


### PR DESCRIPTION
### Summary
We can't really know when to trim, and if there are body args, it won't trim the resulting rendered template anyway.
We could add more methods, but it will sort of have to be up to the caller if they want to trim or not.