### PR TITLE
add additional token call params to BaseJWTRefreshTokenCookiesUserLoginSecurityContext

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.4.14"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.33.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.34.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.33.1</version>
+  <version>4.34.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
+++ b/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
@@ -85,6 +85,10 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
     this.refreshTokenCookie = new CookieProxy(refreshTokenCookieName(), (long) Integer.MAX_VALUE, cookieSameSite());
   }
 
+  public Map<String, List<String>> additionalTokenCallParams() {
+    return Map.of();
+  }
+
   @Override
   public Object getCurrentUser() {
     // Cache in the request
@@ -287,6 +291,8 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
       body.put("client_id", List.of(oauthConfiguration.clientId));
       body.put("client_secret", List.of(oauthConfiguration.clientSecret));
     }
+
+    body.putAll(additionalTokenCallParams());
 
     HttpRequest refreshRequest = requestBuilder.header(Headers.ContentType, ContentTypes.Form)
                                                .POST(new FormBodyPublisher(body))

--- a/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
+++ b/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
@@ -85,10 +85,6 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
     this.refreshTokenCookie = new CookieProxy(refreshTokenCookieName(), (long) Integer.MAX_VALUE, cookieSameSite());
   }
 
-  public Map<String, List<String>> additionalTokenCallParams() {
-    return Map.of();
-  }
-
   @Override
   public Object getCurrentUser() {
     // Cache in the request
@@ -292,7 +288,7 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
       body.put("client_secret", List.of(oauthConfiguration.clientSecret));
     }
 
-    body.putAll(additionalTokenCallParams());
+    body.putAll(oauthConfiguration.additionalParameters);
 
     HttpRequest refreshRequest = requestBuilder.header(Headers.ContentType, ContentTypes.Form)
                                                .POST(new FormBodyPublisher(body))

--- a/src/main/java/org/primeframework/mvc/security/oauth/OAuthConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/security/oauth/OAuthConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/primeframework/mvc/security/oauth/OAuthConfiguration.java
+++ b/src/main/java/org/primeframework/mvc/security/oauth/OAuthConfiguration.java
@@ -15,12 +15,18 @@
  */
 package org.primeframework.mvc.security.oauth;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.primeframework.mvc.util.Buildable;
 
 /**
  * @author Daniel DeGroff
  */
 public class OAuthConfiguration implements Buildable<OAuthConfiguration> {
+  public Map<String, List<String>> additionalParameters = new HashMap<>();
+
   public TokenAuthenticationMethod authenticationMethod = TokenAuthenticationMethod.client_secret_basic;
 
   public String clientId;

--- a/src/test/java/org/example/action/oauth/TokenAction.java
+++ b/src/test/java/org/example/action/oauth/TokenAction.java
@@ -74,7 +74,7 @@ public class TokenAction {
     // if additional parameters were sent, validate them
     MockOAuthUserLoginSecurityContext.additionalParameters.forEach((key, value) -> {
       assertTrue(unknownParameters.containsKey(key), "Missing additional parameter: " + key);
-      assertEquals(unknownParameters.get(key), value.toArray(new String[0]), "Mismatched additional parameter value for: " + key);
+      assertEquals(unknownParameters.get(key), value.toArray(), "Mismatched additional parameter value for: " + key);
     });
 
     JWT jwt = new JWT();

--- a/src/test/java/org/example/action/oauth/TokenAction.java
+++ b/src/test/java/org/example/action/oauth/TokenAction.java
@@ -39,6 +39,9 @@ import static org.testng.Assert.assertTrue;
 @Action
 @JSON
 public class TokenAction {
+  @UnknownParameters
+  public static Map<String, String[]> UnknownParameters = new HashMap<>();
+
   @FieldName("client_id")
   public String clientId;
 
@@ -51,9 +54,6 @@ public class TokenAction {
 
   @JSONResponse
   public RefreshResponse response = new RefreshResponse();
-
-  @UnknownParameters
-  public Map<String, String[]> unknownParameters = new HashMap<>();
 
   @Inject
   private HTTPRequest httpRequest;
@@ -70,12 +70,6 @@ public class TokenAction {
       case client_secret_basic -> assertEquals(httpRequest.getHeader("Authorization"), "Basic dGhlIGNsaWVudCBJRDp0aGUgY2xpZW50IHNlY3JldA==");
       case none -> assertTrue(true);
     }
-
-    // if additional parameters were sent, validate them
-    MockOAuthUserLoginSecurityContext.additionalParameters.forEach((key, value) -> {
-      assertTrue(unknownParameters.containsKey(key), "Missing additional parameter: " + key);
-      assertEquals(unknownParameters.get(key), value.toArray(), "Mismatched additional parameter value for: " + key);
-    });
 
     JWT jwt = new JWT();
     jwt.audience = "prime-tests";

--- a/src/test/java/org/example/action/oauth/TokenAction.java
+++ b/src/test/java/org/example/action/oauth/TokenAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
+++ b/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
@@ -27,6 +27,7 @@ import io.fusionauth.http.server.HTTPListenerConfiguration;
 import io.fusionauth.http.server.HTTPRequest;
 import io.fusionauth.http.server.HTTPResponse;
 import io.fusionauth.http.server.HTTPServerConfiguration;
+import org.example.action.oauth.TokenAction;
 import org.primeframework.mvc.PrimeBaseTest.TestContentModule;
 import org.primeframework.mvc.PrimeBaseTest.TestMVCConfigurationModule;
 import org.primeframework.mvc.cors.CORSConfigurationProvider;
@@ -50,6 +51,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Brian Pontarelli
@@ -261,8 +264,8 @@ public class JWTRefreshTokenLoginTest {
   @Test
   public void refreshTokenEndpoint_additionalParameters() {
     // The token action should get called with the additional parameters we configure on the security context.
-    // This will be validated in the TokenAction.
-    MockOAuthUserLoginSecurityContext.additionalParameters.put("tenantId", List.of(new UUID(5, 0).toString()));
+    var tenantId = new UUID(5, 0).toString();
+    MockOAuthUserLoginSecurityContext.additionalParameters.put("tenantId", List.of(tenantId));
     MockOAuthUserLoginSecurityContext.TokenEndpoint = "http://localhost:" + simulator.getPort() + "/oauth/token";
     MockOAuthUserLoginSecurityContext.ValidateJWTOnLogin = false;
 
@@ -279,6 +282,11 @@ public class JWTRefreshTokenLoginTest {
              .get()
              .assertStatusCode(200)
              .assertBodyContains("Logged in");
+
+    // Ensure that the tenantId was added to the request and caught in unknown parameters
+    // if additional parameters were sent, validate them
+    assertTrue(TokenAction.UnknownParameters.containsKey("tenantId"), "Missing tenantId in unknown parameters");
+    assertEquals(TokenAction.UnknownParameters.get("tenantId"), new String[]{tenantId}, "Mismatched tenantId in unknown parameters");
   }
 
   public static class TestScopeModule extends AbstractModule {

--- a/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
+++ b/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
@@ -271,6 +271,8 @@ public class JWTRefreshTokenLoginTest {
 
     // Setting 'expired: true' on the request just tells the Login action to create an expired JWT and store it in the LoginContext.
     // - So we expect this to succeed, but the login context wil now contain an expired JWT. This means it will be refreshed on first use.
+    //
+    // The refresh action is what will call the token endpoint with the additional parameters.
     simulator.test("/oauth/login")
              .withParameter("expired", "true")
              .post()

--- a/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
+++ b/src/test/java/org/primeframework/mvc/JWTRefreshTokenLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2021-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -53,6 +53,7 @@ import io.fusionauth.http.server.HTTPRequest;
 import io.fusionauth.http.server.HTTPResponse;
 import io.fusionauth.http.server.HTTPServerConfiguration;
 import org.example.action.SecureAction;
+import org.example.action.oauth.TokenAction;
 import org.example.action.user.EditAction;
 import org.primeframework.mvc.action.ActionInvocation;
 import org.primeframework.mvc.action.ExecuteMethodConfiguration;
@@ -219,6 +220,7 @@ public abstract class PrimeBaseTest {
     // Reset
     EditAction.getCalled = false;
     SecureAction.UnknownParameters.clear();
+    TokenAction.UnknownParameters.clear();
 
     TestUnhandledExceptionHandler.reset();
 

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -80,6 +80,7 @@ import org.primeframework.mvc.message.scope.RequestScope;
 import org.primeframework.mvc.security.CBCCipherProvider;
 import org.primeframework.mvc.security.CipherProvider;
 import org.primeframework.mvc.security.GCMCipherProvider;
+import org.primeframework.mvc.security.MockOAuthUserLoginSecurityContext;
 import org.primeframework.mvc.security.MockStaticClasspathResourceFilter;
 import org.primeframework.mvc.security.MockStaticResourceFilter;
 import org.primeframework.mvc.security.MockUserLoginSecurityContext;
@@ -200,6 +201,9 @@ public abstract class PrimeBaseTest {
     // Clear the roles and logged in user
     MockUserLoginSecurityContext.roles.clear();
     MockUserLoginSecurityContext.currentUser = null;
+
+    // clear any additional params set in the MockOAuthUserLoginSecurityContext
+    MockOAuthUserLoginSecurityContext.additionalParameters.clear();
 
     // Reset CSRF configuration
     configuration.csrfEnabled = false;

--- a/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
+++ b/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2023, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2016-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
+++ b/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
@@ -15,8 +15,12 @@
  */
 package org.primeframework.mvc.security;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import com.google.inject.Inject;
 import io.fusionauth.http.server.HTTPRequest;
@@ -36,6 +40,8 @@ public class MockOAuthUserLoginSecurityContext extends BaseJWTRefreshTokenCookie
   public static String TokenEndpoint = "http://localhost:8000/oauth/token";
 
   public static boolean ValidateJWTOnLogin = true;
+
+  public static Map<String, List<String>> additionalParameters = new HashMap<>();
 
   public static String clientId;
 
@@ -95,7 +101,8 @@ public class MockOAuthUserLoginSecurityContext extends BaseJWTRefreshTokenCookie
     return new OAuthConfiguration().with(c -> c.authenticationMethod = tokenAuthenticationMethod)
                                    .with(c -> c.clientId = clientId)
                                    .with(c -> c.clientSecret = clientSecret)
-                                   .with(c -> c.tokenEndpoint = TokenEndpoint);
+                                   .with(c -> c.tokenEndpoint = TokenEndpoint)
+                                   .with(c -> c.additionalParameters.putAll(additionalParameters));
   }
 
   @Override


### PR DESCRIPTION
The primary need for this is that we are now adding, and in some cases (like universal apps) mandating that a tenantId is present on the calls to /oauth2/token. This allows anything extending the base context to add any additional params to that call