### PR TITLE
allow @JWTAuthorize for other JWT based schemes

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.4.14"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.34.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.35.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>4.34.0</version>
+  <version>4.35.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
+++ b/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
@@ -463,7 +463,7 @@ public class DefaultActionConfigurationBuilder implements ActionConfigurationBui
       throw new PrimeException("The action class [" + actionClass + "] is missing at a JWT Authorization method. " +
                                "The class must define one or more methods annotated " + JWTAuthorizeMethod.class.getSimpleName() + " when [jwtEnabled] " +
                                "is set to [true] which deprecated, or you are using a jwt based security scheme. You action has" +
-                               " defined the following security schemes [" + String.join(", ", securitySchemes) + "].Ensure that for each execute " +
+                               " defined the following security schemes [" + String.join(", ", securitySchemes) + "]. Ensure that for each execute " +
                                "method in your action such as post, put, get and delete that a method is configured to authorize the JWT.");
     }
 

--- a/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
+++ b/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2012-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -412,8 +412,15 @@ public class DefaultActionConfigurationBuilder implements ActionConfigurationBui
   protected Map<HTTPMethod, List<JWTMethodConfiguration>> findJwtAuthorizationMethods(Class<?> actionClass,
                                                                                       List<String> securitySchemes,
                                                                                       Map<HTTPMethod, ExecuteMethodConfiguration> executeMethods) {
-    // When JWT scheme is not enabled, we will not call any of the JWT Authorization Methods.
-    if (!securitySchemes.contains("jwt")) {
+    // When a JWT scheme is not enabled, we will not call any of the JWT Authorization Methods.
+    // - Note that anyone can bind a jwt security scheme, and they may wish to use these authorization methods.
+    //   So as long as the scheme contains "jwt", bind them. For example, you may wish to bind `jwt-1` and `jwt-` with
+    //   different constraint validations.
+    // - In theory we could just always bind them, however we do validate that the action is properly configured to
+    //   have a method to cover the expected HTTP verbs, etc. Ideally we would keep this logic to keep the user from
+    //   not using these methods correctly. But if we wanted to tell the user it's their problem, we could remove
+    //   some of that validation and just always bind them.
+    if (securitySchemes.stream().noneMatch(s -> s.contains("jwt"))) {
       return Collections.emptyMap();
     }
 
@@ -454,15 +461,17 @@ public class DefaultActionConfigurationBuilder implements ActionConfigurationBui
 
     if (!jwtMethods.keySet().containsAll(authenticatedMethods)) {
       throw new PrimeException("The action class [" + actionClass + "] is missing at a JWT Authorization method. " +
-                               "The class must define one or more methods annotated " + JWTAuthorizeMethod.class.getSimpleName() + " when [jwtEnabled] is set to [true]. "
-                               + "Ensure that for each execute method in your action such as post, put, get and delete that a method is configured to authorize the JWT.");
+                               "The class must define one or more methods annotated " + JWTAuthorizeMethod.class.getSimpleName() + " when [jwtEnabled] " +
+                               "is set to [true] which deprecated, or you are using a jwt based security scheme. You action has" +
+                               " defined the following security schemes [" + String.join(", ", securitySchemes) + "].Ensure that for each execute " +
+                               "method in your action such as post, put, get and delete that a method is configured to authorize the JWT.");
     }
 
     return jwtMethods;
   }
 
   /**
-   * Finds all of the result configurations for the action class.
+   * Finds all the result configurations for the action class.
    *
    * @param actionClass The action class.
    * @return The map of all the result configurations.

--- a/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
+++ b/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
@@ -414,7 +414,7 @@ public class DefaultActionConfigurationBuilder implements ActionConfigurationBui
                                                                                       Map<HTTPMethod, ExecuteMethodConfiguration> executeMethods) {
     // When a JWT scheme is not enabled, we will not call any of the JWT Authorization Methods.
     // - Note that anyone can bind a jwt security scheme, and they may wish to use these authorization methods.
-    //   So as long as the scheme contains "jwt", bind them. For example, you may wish to bind `jwt-1` and `jwt-` with
+    //   So as long as the scheme contains "jwt", bind them. For example, you may wish to bind `jwt-1` and `jwt-2` with
     //   different constraint validations.
     // - In theory we could just always bind them, however we do validate that the action is properly configured to
     //   have a method to cover the expected HTTP verbs, etc. Ideally we would keep this logic to keep the user from

--- a/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
+++ b/src/main/java/org/primeframework/mvc/action/config/DefaultActionConfigurationBuilder.java
@@ -462,7 +462,7 @@ public class DefaultActionConfigurationBuilder implements ActionConfigurationBui
     if (!jwtMethods.keySet().containsAll(authenticatedMethods)) {
       throw new PrimeException("The action class [" + actionClass + "] is missing at a JWT Authorization method. " +
                                "The class must define one or more methods annotated " + JWTAuthorizeMethod.class.getSimpleName() + " when [jwtEnabled] " +
-                               "is set to [true] which deprecated, or you are using a jwt based security scheme. You action has" +
+                               "is set to [true], which is deprecated, or you are using a jwt based security scheme. Your action has" +
                                " defined the following security schemes [" + String.join(", ", securitySchemes) + "]. Ensure that for each execute " +
                                "method in your action such as post, put, get and delete that a method is configured to authorize the JWT.");
     }

--- a/src/test/java/org/example/action/JwtAuthorizedAction.java
+++ b/src/test/java/org/example/action/JwtAuthorizedAction.java
@@ -24,13 +24,12 @@ import org.primeframework.mvc.security.annotation.JWTAuthorizeMethod;
 /**
  * @author Daniel DeGroff
  */
-@Action(requiresAuthentication = true, jwtEnabled = true)
+@Action(requiresAuthentication = true, scheme = "jwt")
 @Status.List({
     @Status(),
     @Status(code = "unauthenticated", status = 401),
     @Status(code = "unauthorized", status = 401)
 })
-// Use the deprecated jwtEnabled on the action instead of 'jwt' scheme
 public class JwtAuthorizedAction {
   public static boolean authorized;
 

--- a/src/test/java/org/example/action/JwtAuthorizedDeprecatedAction.java
+++ b/src/test/java/org/example/action/JwtAuthorizedDeprecatedAction.java
@@ -24,14 +24,14 @@ import org.primeframework.mvc.security.annotation.JWTAuthorizeMethod;
 /**
  * @author Daniel DeGroff
  */
-@Action(requiresAuthentication = true, scheme = "jwt")
+@Action(requiresAuthentication = true, jwtEnabled = true)
 @Status.List({
     @Status(),
     @Status(code = "unauthenticated", status = 401),
     @Status(code = "unauthorized", status = 401)
 })
-// Use the 'jwt' scheme
-public class JwtAuthorizedLatestAction {
+// Use the deprecated jwtEnabled instead of scheme = jwt
+public class JwtAuthorizedDeprecatedAction {
   @JWTAuthorizeMethod(httpMethods = {Methods.GET})
   public boolean authorize(JWT jwt) {
     return true;

--- a/src/test/java/org/example/action/JwtAuthorizedDisabledAction.java
+++ b/src/test/java/org/example/action/JwtAuthorizedDisabledAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2016-2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,16 @@ import org.primeframework.mvc.security.annotation.JWTAuthorizeMethod;
 /**
  * @author Daniel DeGroff
  */
-@Action(requiresAuthentication = true, jwtEnabled = false)
+@Action(requiresAuthentication = true, scheme = "jwt")
 @Status.List({
     @Status(code = "success", status = 200),
     @Status(code = "unauthenticated", status = 401),
     @Status(code = "unauthorized", status = 401)
 })
 public class JwtAuthorizedDisabledAction {
-
-  public boolean authorized;
-
   @JWTAuthorizeMethod
   public boolean authorize(JWT jwt) {
-    return authorized;
+    return false;
   }
 
   public String get() {

--- a/src/test/java/org/example/action/JwtAuthorizedLatestAction.java
+++ b/src/test/java/org/example/action/JwtAuthorizedLatestAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,19 +24,17 @@ import org.primeframework.mvc.security.annotation.JWTAuthorizeMethod;
 /**
  * @author Daniel DeGroff
  */
-@Action(requiresAuthentication = true, jwtEnabled = true)
+@Action(requiresAuthentication = true, scheme = "jwt")
 @Status.List({
     @Status(),
     @Status(code = "unauthenticated", status = 401),
     @Status(code = "unauthorized", status = 401)
 })
-// Use the deprecated jwtEnabled on the action instead of 'jwt' scheme
-public class JwtAuthorizedAction {
-  public static boolean authorized;
-
+// Use the 'jwt' scheme
+public class JwtAuthorizedLatestAction {
   @JWTAuthorizeMethod(httpMethods = {Methods.GET})
   public boolean authorize(JWT jwt) {
-    return authorized;
+    return true;
   }
 
   public String get() {

--- a/src/test/java/org/example/action/JwtAuthorizedOtherAction.java
+++ b/src/test/java/org/example/action/JwtAuthorizedOtherAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2025, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2025, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,19 +24,17 @@ import org.primeframework.mvc.security.annotation.JWTAuthorizeMethod;
 /**
  * @author Daniel DeGroff
  */
-@Action(requiresAuthentication = true, jwtEnabled = true)
+@Action(requiresAuthentication = true, scheme = "jwt-other")
 @Status.List({
     @Status(),
     @Status(code = "unauthenticated", status = 401),
     @Status(code = "unauthorized", status = 401)
 })
-// Use the deprecated jwtEnabled on the action instead of 'jwt' scheme
-public class JwtAuthorizedAction {
-  public static boolean authorized;
-
+// Use a jwt scheme with a suffix, as long as the scheme name contains jwt it will work.
+public class JwtAuthorizedOtherAction {
   @JWTAuthorizeMethod(httpMethods = {Methods.GET})
   public boolean authorize(JWT jwt) {
-    return authorized;
+    return true;
   }
 
   public String get() {

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -808,14 +808,12 @@ public class GlobalTest extends PrimeBaseTest {
   public void get_jwtDisabledJwtAuthentication() throws Exception {
     // Send in a JWT Authorization header when the Action has JWT disabled. Should always get a 401. When a JWT is provided, the action expects JWT to be enabled.
     test.simulate(() -> simulator.test("/jwt-authorized-disabled")
-                                 .withURLParameter("authorized", true)
                                  .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
                                  .get()
                                  .assertStatusCode(401));
 
     // Same, use Bearer scheme
     test.simulate(() -> simulator.test("/jwt-authorized-disabled")
-                                 .withURLParameter("authorized", true)
                                  .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
                                  .get()
                                  .assertStatusCode(401));
@@ -867,9 +865,9 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
-  public void get_jwt_other_scheme() throws Exception {
-    // Test an action with a jwt based scheme, but not named 'jwt'
-    test.simulate(() -> simulator.test("/jwt-authorized-other")
+  public void get_jwt_jwtEnabled_deprecated() throws Exception {
+    // Test an action using the deprecated jwtEnabled instead of the jwt scheme
+    test.simulate(() -> simulator.test("/jwt-authorized-deprecated")
                                  .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
                                  .get()
                                  .assertHeaderContains("Cache-Control", "no-cache")
@@ -877,9 +875,9 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
-  public void get_jwt_scheme() throws Exception {
-    // Test an action using the 'scheme' instead of jwtEnabled
-    test.simulate(() -> simulator.test("/jwt-authorized-latest")
+  public void get_jwt_other_scheme() throws Exception {
+    // Test an action with a jwt based scheme, but not named 'jwt'
+    test.simulate(() -> simulator.test("/jwt-authorized-other")
                                  .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
                                  .get()
                                  .assertHeaderContains("Cache-Control", "no-cache")

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -867,6 +867,26 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
+  public void get_jwt_other_scheme() throws Exception {
+    // Test and action with a jwt based scheme, but not named 'jwt'
+    test.simulate(() -> simulator.test("/jwt-authorized-other")
+                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                                 .get()
+                                 .assertHeaderContains("Cache-Control", "no-cache")
+                                 .assertStatusCode(200));
+  }
+
+  @Test
+  public void get_jwt_scheme() throws Exception {
+    // Test an action using the 'scheme' instead of jwtEnabled
+    test.simulate(() -> simulator.test("/jwt-authorized-latest")
+                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                                 .get()
+                                 .assertHeaderContains("Cache-Control", "no-cache")
+                                 .assertStatusCode(200));
+  }
+
+  @Test
   public void get_largeFTL() {
     simulator.test("/large-ftl")
              .get()

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -868,7 +868,7 @@ public class GlobalTest extends PrimeBaseTest {
 
   @Test
   public void get_jwt_other_scheme() throws Exception {
-    // Test and action with a jwt based scheme, but not named 'jwt'
+    // Test an action with a jwt based scheme, but not named 'jwt'
     test.simulate(() -> simulator.test("/jwt-authorized-other")
                                  .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
                                  .get()

--- a/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
+++ b/src/test/java/org/primeframework/mvc/PrimeBaseTest.java
@@ -80,6 +80,7 @@ import org.primeframework.mvc.message.scope.RequestScope;
 import org.primeframework.mvc.security.CBCCipherProvider;
 import org.primeframework.mvc.security.CipherProvider;
 import org.primeframework.mvc.security.GCMCipherProvider;
+import org.primeframework.mvc.security.JWTSecurityScheme;
 import org.primeframework.mvc.security.MockOAuthUserLoginSecurityContext;
 import org.primeframework.mvc.security.MockStaticClasspathResourceFilter;
 import org.primeframework.mvc.security.MockStaticResourceFilter;
@@ -89,6 +90,7 @@ import org.primeframework.mvc.security.StaticResourceFilter;
 import org.primeframework.mvc.security.UserLoginSecurityContext;
 import org.primeframework.mvc.security.VerifierProvider;
 import org.primeframework.mvc.security.csrf.CSRFProvider;
+import org.primeframework.mvc.security.guice.SecuritySchemeFactory;
 import org.primeframework.mvc.test.RequestBuilder.HTTPRequestConsumer;
 import org.primeframework.mvc.test.RequestSimulator;
 import org.primeframework.mvc.util.ThrowingRunnable;
@@ -248,6 +250,7 @@ public abstract class PrimeBaseTest {
         bind(MessageObserver.class).toInstance(messageObserver);
         bind(MetricRegistry.class).toInstance(metricRegistry);
         bind(UserLoginSecurityContext.class).to(MockUserLoginSecurityContext.class);
+        SecuritySchemeFactory.addSecurityScheme(binder(), "jwt-other", JWTSecurityScheme.class);
 
         // Test Content-Type
         ContentHandlerFactory.addContentHandler(binder(), "application/test+json", JacksonContentHandler.class);


### PR DESCRIPTION
### Summary
Allow for other JWT based security schemes to use the `@JWTAuthorizeMethod` method

### Related
- https://github.com/prime-framework/prime-mvc/pull/89