### PR TITLE
Pass both the encoded and decoded to retrieveUserForJWT

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.4.14"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "4.35.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "4.36.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
+++ b/src/main/java/org/primeframework/mvc/security/BaseJWTRefreshTokenCookiesUserLoginSecurityContext.java
@@ -98,7 +98,7 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
       return null;
     }
 
-    user = retrieveUserForJWT(tokens.jwt);
+    user = retrieveUserForJWT(tokens.decodedJWT, tokens.jwt);
     if (user == null) {
       jwtCookie.delete(request, response);
     } else {
@@ -207,12 +207,13 @@ public abstract class BaseJWTRefreshTokenCookiesUserLoginSecurityContext impleme
   protected abstract String refreshTokenCookieName();
 
   /**
-   * Retrieve a user given an encoded JWT string.
+   * Retrieve a user with the encoded JWT string or the decoded JWT object.
    *
-   * @param jwt the encoded JWT string
+   * @param decodedJWT the decoded JWT object
+   * @param jwt        the encoded JWT string
    * @return a user object.
    */
-  protected abstract Object retrieveUserForJWT(String jwt);
+  protected abstract Object retrieveUserForJWT(JWT decodedJWT, String jwt);
 
   /**
    * The JWT that is passed to this method is known to be valid. The signature has been validated, and the JWT is not expired.

--- a/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
+++ b/src/test/java/org/primeframework/mvc/security/MockOAuthUserLoginSecurityContext.java
@@ -20,11 +20,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import com.google.inject.Inject;
 import io.fusionauth.http.server.HTTPRequest;
 import io.fusionauth.http.server.HTTPResponse;
+import io.fusionauth.jwt.domain.JWT;
 import org.primeframework.mvc.security.oauth.OAuthConfiguration;
 import org.primeframework.mvc.security.oauth.TokenAuthenticationMethod;
 import org.primeframework.mvc.security.oauth.Tokens;
@@ -111,7 +111,7 @@ public class MockOAuthUserLoginSecurityContext extends BaseJWTRefreshTokenCookie
   }
 
   @Override
-  protected Object retrieveUserForJWT(String jwt) {
+  protected Object retrieveUserForJWT(JWT decodedJWT, String jwt) {
     return CurrentUser;
   }
 }


### PR DESCRIPTION
### Summary 
Pass in both the encoded and decoded version of the JWT to `retrieveUserForJWT`

This provides additional flexibility for the implementation to user the JWT directly, or a claim from the JWT to retrieve the user.

