### PR TITLE
Detect unused variables in tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: setup java  
+      - name: setup java
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: |
-           21
-           17
+            21
+            17
       - name: savant setup
         run: |
           curl -O https://repository.savantbuild.org/org/savantbuild/savant-core/2.0.0/savant-2.0.0.tar.gz
@@ -48,12 +48,6 @@ jobs:
       - name: run tests/integrate
         run: |
           sb clean int
-      - name: publish test report
-        # v4
-        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          report_paths: 'build/test-reports/junitreports/**/*.xml'
       - name: capture reports
         uses: actions/upload-artifact@v4
         if: success() || failure() # always run even if the previous step fails

--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.6.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.6.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.5.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.6.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.5.1</version>
+  <version>5.6.1</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.6.1</version>
+  <version>5.6.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -106,10 +106,10 @@ public final class BodyTools {
       Set<Object> unusedVariables = values.getUnusedVariables("_",
                                                               "actual");
       if (!unusedVariables.isEmpty()) {
-        throw new IllegalArgumentException("The following variables are not used in the [%s] template: %s".formatted(path,
-                                                                                                                     unusedVariables.stream()
-                                                                                                                                    .sorted()
-                                                                                                                                    .toList()));
+        throw new IllegalArgumentException("Variables %s are not used in the [%s] template. If it's acceptable for the variable to not be used, wrap it in an Optional".formatted(unusedVariables.stream()
+                                                                                                                                                                                                 .sorted()
+                                                                                                                                                                                                 .toList(),
+                                                                                                                                                                                  path));
       }
       return writer.toString();
     } catch (TemplateException e) {

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -105,10 +105,10 @@ public final class BodyTools {
       Set<Object> unusedVariables = values.getUnusedVariables("_",
                                                               "actual");
       if (!unusedVariables.isEmpty()) {
-        throw new IllegalArgumentException("Variables %s are not used in the [%s] template. If it's acceptable for the variable to not be used, wrap it in an Optional".formatted(unusedVariables.stream()
-                                                                                                                                                                                                 .sorted()
-                                                                                                                                                                                                 .toList(),
-                                                                                                                                                                                  path));
+        throw new IllegalArgumentException("Unused values %s found in the [%s] template. If it's acceptable for the variable to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
+                                                                                                                                                                                            .sorted()
+                                                                                                                                                                                            .toList(),
+                                                                                                                                                                             path));
       }
       return writer.toString();
     } catch (TemplateException e) {

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -101,7 +101,8 @@ public final class BodyTools {
 
     try {
       template.process(values, writer);
-      Set<Object> unusedVariables = values.getUnusedVariables();
+      // used in some classes like RequestResult, and should be ignored
+      Set<Object> unusedVariables = values.getUnusedVariables("_to_milli");
       if (!unusedVariables.isEmpty()) {
         throw new IllegalArgumentException("The following variables are not used in the [%s] template: %s".formatted(path,
                                                                                                                      unusedVariables));

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -51,7 +51,7 @@ public final class BodyTools {
    * @throws IOException If the template could not be loaded, parsed or executed.
    */
   public static String processTemplate(Path path, Object... values) throws IOException {
-    return processTemplateWithMap(path, toMap(values), false);
+    return processTemplateWithMap(path, toMap(values));
   }
 
   /**
@@ -67,7 +67,7 @@ public final class BodyTools {
    * @throws IOException If the template could not be loaded, parsed or executed.
    */
   public static String processTemplateForAssertion(Path path, Object... values) throws IOException {
-    return processTemplateWithMap(path, toMap(values), true);
+    return processTemplateWithMap(path, toMap(values));
   }
 
   /**
@@ -79,13 +79,12 @@ public final class BodyTools {
    *     .done());
    * </pre>
    *
-   * @param path                   Path to the FreeMarker template.
-   * @param values                 Map of key value pairs of replacement values.
-   * @param createMissingTemplates set true to create templates when they do not exists
+   * @param path   Path to the FreeMarker template.
+   * @param values Map of key value pairs of replacement values.
    * @return The result of executing the template.
    * @throws IOException If the template could not be loaded, parsed or executed.
    */
-  public static String processTemplateWithMap(Path path, DetectionMap values, boolean createMissingTemplates)
+  public static String processTemplateWithMap(Path path, DetectionMap values)
       throws IOException {
     StringWriter writer = new StringWriter();
     Template template = null;

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -107,7 +107,9 @@ public final class BodyTools {
                                                               "actual");
       if (!unusedVariables.isEmpty()) {
         throw new IllegalArgumentException("The following variables are not used in the [%s] template: %s".formatted(path,
-                                                                                                                     unusedVariables));
+                                                                                                                     unusedVariables.stream()
+                                                                                                                                    .sorted()
+                                                                                                                                    .toList()));
       }
       return writer.toString();
     } catch (TemplateException e) {

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -101,8 +101,8 @@ public final class BodyTools {
 
     try {
       template.process(values, writer);
-      // used in some classes like RequestResult, and should be ignored
-      Set<Object> unusedVariables = values.getUnusedVariables("_to_milli");
+      // used in some classes like RequestResult, and should be ignored. Other implementations may also add functions, etc. that start with _
+      Set<Object> unusedVariables = values.getUnusedVariables("_");
       if (!unusedVariables.isEmpty()) {
         throw new IllegalArgumentException("The following variables are not used in the [%s] template: %s".formatted(path,
                                                                                                                      unusedVariables));

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -102,7 +102,9 @@ public final class BodyTools {
     try {
       template.process(values, writer);
       // used in some classes like RequestResult, and should be ignored. Other implementations may also add functions, etc. that start with _
-      Set<Object> unusedVariables = values.getUnusedVariables("_");
+      // 'actual' is also used in assertJSONFileWithActual
+      Set<Object> unusedVariables = values.getUnusedVariables("_",
+                                                              "actual");
       if (!unusedVariables.isEmpty()) {
         throw new IllegalArgumentException("The following variables are not used in the [%s] template: %s".formatted(path,
                                                                                                                      unusedVariables));

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -39,6 +39,22 @@ public class BodyToolsTest {
   }
 
   @Test
+  public void processTemplateWithMap_to_milli() throws Exception {
+    // arrange
+    DetectionMap values = new DetectionMap();
+    // used in some classes like RequestResult, and should be ignored
+    values.put("_to_milli", "howdy");
+
+    // act
+    String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
+                                                     values,
+                                                     false);
+
+    // assert
+    assertEquals(result, "missing");
+  }
+
+  @Test
   public void processTemplateWithMap_unused_variables() throws Exception {
     // arrange
     DetectionMap values = new DetectionMap();

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -32,8 +32,8 @@ public class BodyToolsTest {
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                                     values,
-                                                     false);
+                                                     values
+    );
 
     // assert
     assertEquals(result, "howdy");
@@ -49,8 +49,8 @@ public class BodyToolsTest {
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                                     values,
-                                                     false);
+                                                     values
+    );
 
     // assert
     assertEquals(result, "missing");
@@ -64,8 +64,8 @@ public class BodyToolsTest {
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                                     values,
-                                                     false);
+                                                     values
+    );
 
     // assert
     assertEquals(result, "howdy");
@@ -79,8 +79,8 @@ public class BodyToolsTest {
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                                     values,
-                                                     false);
+                                                     values
+    );
 
     // assert
     assertEquals(result, "howdy");
@@ -95,8 +95,8 @@ public class BodyToolsTest {
     // act + assert
     try {
       BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                       values,
-                                       false);
+                                       values
+      );
       fail("Expected an exception");
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -101,7 +101,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "Variables [othervariable] are not used in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the variable to not be used, wrap it in an Optional",
+      assertEquals(e.getMessage(), "Unused values [othervariable] found in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the variable to be unused, wrap it in an Optional",
                    "othervariable is in the map but is not used");
     }
   }

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -39,11 +39,12 @@ public class BodyToolsTest {
   }
 
   @Test
-  public void processTemplateWithMap_to_milli() throws Exception {
+  public void processTemplateWithMap_functions() throws Exception {
     // arrange
     DetectionMap values = new DetectionMap();
     // used in some classes like RequestResult, and should be ignored
-    values.put("_to_milli", "howdy");
+    values.putAll(Map.of("_to_milli", "howdy",
+                         "actual", "someactualthing"));
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.test;
+
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class BodyToolsTest {
+  @Test
+  public void processTemplateWithMap_all_variables_used() throws Exception {
+    // arrange
+    Map<String, Object> values = Map.of("message", "howdy");
+
+    // act
+    String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
+                                                     values,
+                                                     false);
+
+    // assert
+    assertEquals(result, "howdy");
+  }
+
+  @Test
+  public void processTemplateWithMap_unused_variables() throws Exception {
+    // arrange
+    Map<String, Object> values = Map.of("message", "howdy", "othervariable", "value");
+
+    // act + assert
+    try {
+      BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
+                                       values,
+                                       false);
+      fail("Expected an exception");
+    } catch (Exception e) {
+      assertEquals(e.getClass(), IllegalArgumentException.class,
+                   "Expected this exception type");
+      assertEquals(e.getMessage(), "The following variables are not used in the [src/test/web/templates/echo.ftl] template: othervariable",
+                   "othervariable is in the map but is not used");
+    }
+  }
+}

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -26,7 +26,8 @@ public class BodyToolsTest {
   @Test
   public void processTemplateWithMap_all_variables_used() throws Exception {
     // arrange
-    Map<String, Object> values = Map.of("message", "howdy");
+    DetectionMap values = new DetectionMap();
+    values.put("message", "howdy");
 
     // act
     String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
@@ -40,7 +41,8 @@ public class BodyToolsTest {
   @Test
   public void processTemplateWithMap_unused_variables() throws Exception {
     // arrange
-    Map<String, Object> values = Map.of("message", "howdy", "othervariable", "value");
+    DetectionMap values = new DetectionMap();
+    values.putAll(Map.of("message", "howdy", "othervariable", "value"));
 
     // act + assert
     try {
@@ -51,7 +53,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "The following variables are not used in the [src/test/web/templates/echo.ftl] template: othervariable",
+      assertEquals(e.getMessage(), "The following variables are not used in the [src/test/web/templates/echo.ftl] template: [othervariable]",
                    "othervariable is in the map but is not used");
     }
   }

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -101,7 +101,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "The following variables are not used in the [src/test/web/templates/echo.ftl] template: [othervariable]",
+      assertEquals(e.getMessage(), "Variables [othervariable] are not used in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the variable to not be used, wrap it in an Optional",
                    "othervariable is in the map but is not used");
     }
   }

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -17,6 +17,7 @@ package org.primeframework.mvc.test;
 
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Optional;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
@@ -53,6 +54,36 @@ public class BodyToolsTest {
 
     // assert
     assertEquals(result, "missing");
+  }
+
+  @Test
+  public void processTemplateWithMap_optional_variable_unused() throws Exception {
+    // arrange
+    DetectionMap values = new DetectionMap();
+    values.putAll(Map.of("message", "howdy", "othervariable", Optional.of("value")));
+
+    // act
+    String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
+                                                     values,
+                                                     false);
+
+    // assert
+    assertEquals(result, "howdy");
+  }
+
+  @Test
+  public void processTemplateWithMap_optional_variable_used() throws Exception {
+    // arrange
+    DetectionMap values = new DetectionMap();
+    values.put("message", Optional.of("howdy"));
+
+    // act
+    String result = BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
+                                                     values,
+                                                     false);
+
+    // assert
+    assertEquals(result, "howdy");
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/test/DetectionMap.java
+++ b/src/test/java/org/primeframework/mvc/test/DetectionMap.java
@@ -17,6 +17,7 @@ package org.primeframework.mvc.test;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -50,6 +51,17 @@ public class DetectionMap extends HashMap<String, Object> {
     Set<String> excludeKeySet = Set.of(excludeKeys);
     return keySet().stream()
                    .filter(key -> !variablesAccessed.contains(key) && !key.startsWith(excludePrefix) && !excludeKeySet.contains(key))
+                   // optional variables do not have to be used in the template
+                   .filter(key -> !(super.get(key) instanceof Optional<?>))
                    .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Object put(String key, Object value) {
+    // go ahead and evaluate optional values for FreeMarker
+    if (value instanceof Optional<?> opt && opt.isPresent()) {
+      value = opt.get();
+    }
+    return super.put(key, value);
   }
 }

--- a/src/test/java/org/primeframework/mvc/test/DetectionMap.java
+++ b/src/test/java/org/primeframework/mvc/test/DetectionMap.java
@@ -38,9 +38,10 @@ public class DetectionMap extends HashMap<String, Object> {
     return super.getOrDefault(key, defaultValue);
   }
 
-  public Set<Object> getUnusedVariables() {
+  public Set<Object> getUnusedVariables(String... excludeKeys) {
+    Set<String> excludeSet = Set.of(excludeKeys);
     return keySet().stream()
-                   .filter(key -> !variablesAccessed.contains(key))
+                   .filter(key -> !variablesAccessed.contains(key) && !excludeSet.contains(key))
                    .collect(Collectors.toSet());
   }
 }

--- a/src/test/java/org/primeframework/mvc/test/DetectionMap.java
+++ b/src/test/java/org/primeframework/mvc/test/DetectionMap.java
@@ -38,10 +38,15 @@ public class DetectionMap extends HashMap<String, Object> {
     return super.getOrDefault(key, defaultValue);
   }
 
-  public Set<Object> getUnusedVariables(String... excludeKeys) {
-    Set<String> excludeSet = Set.of(excludeKeys);
+  /**
+   * Gets variables that were put in the map since instantiation, but not accessed
+   *
+   * @param excludePrefix excludes keys that start with this value
+   * @return unused variables
+   */
+  public Set<Object> getUnusedVariables(String excludePrefix) {
     return keySet().stream()
-                   .filter(key -> !variablesAccessed.contains(key) && !excludeSet.contains(key))
+                   .filter(key -> !variablesAccessed.contains(key) && !key.startsWith(excludePrefix))
                    .collect(Collectors.toSet());
   }
 }

--- a/src/test/java/org/primeframework/mvc/test/DetectionMap.java
+++ b/src/test/java/org/primeframework/mvc/test/DetectionMap.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A map implementation that captures which keys in the map have been accessed.
+ */
+public class DetectionMap extends HashMap<String, Object> {
+  public final Set<String> variablesAccessed = new HashSet<>();
+
+  @Override
+  public Object get(Object key) {
+    variablesAccessed.add((String) key);
+    return super.get(key);
+  }
+
+  @Override
+  public Object getOrDefault(Object key, Object defaultValue) {
+    variablesAccessed.add((String) key);
+    return super.getOrDefault(key, defaultValue);
+  }
+
+  public Set<Object> getUnusedVariables() {
+    return keySet().stream()
+                   .filter(key -> !variablesAccessed.contains(key))
+                   .collect(Collectors.toSet());
+  }
+}

--- a/src/test/java/org/primeframework/mvc/test/DetectionMap.java
+++ b/src/test/java/org/primeframework/mvc/test/DetectionMap.java
@@ -42,11 +42,14 @@ public class DetectionMap extends HashMap<String, Object> {
    * Gets variables that were put in the map since instantiation, but not accessed
    *
    * @param excludePrefix excludes keys that start with this value
+   * @param excludeKeys   exclude these act keys
    * @return unused variables
    */
-  public Set<Object> getUnusedVariables(String excludePrefix) {
+  public Set<Object> getUnusedVariables(String excludePrefix,
+                                        String... excludeKeys) {
+    Set<String> excludeKeySet = Set.of(excludeKeys);
     return keySet().stream()
-                   .filter(key -> !variablesAccessed.contains(key) && !key.startsWith(excludePrefix))
+                   .filter(key -> !variablesAccessed.contains(key) && !key.startsWith(excludePrefix) && !excludeKeySet.contains(key))
                    .collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
When a JSON FTL is specified, detect which variables are sent to render the template vs. which are used.

This eliminates a rather large amount of cruft in applications using this for tests.