### PR TITLE
Fix annoyance with unused variable detection and newly minted files

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.6.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.6.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.6.0</version>
+  <version>5.6.1</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -88,10 +88,12 @@ public final class BodyTools {
       throws IOException {
     StringWriter writer = new StringWriter();
     Template template = null;
+    boolean freshlyCreatedFile = false;
     try {
       template = config.getTemplate(path.toAbsolutePath().toString());
     } catch (TemplateNotFoundException e) {
       if (Files.notExists(path.toAbsolutePath())) {
+        freshlyCreatedFile = true;
         Files.writeString(path.toAbsolutePath(), "{\"prime-mvc-auto-generated\": true}", StandardOpenOption.SYNC, StandardOpenOption.DSYNC, StandardOpenOption.CREATE_NEW);
         config.clearTemplateCache();
         template = config.getTemplate(path.toAbsolutePath().toString());
@@ -104,7 +106,8 @@ public final class BodyTools {
       // 'actual' is also used in assertJSONFileWithActual
       Set<Object> unusedVariables = values.getUnusedVariables("_",
                                                               "actual");
-      if (!unusedVariables.isEmpty()) {
+      // if it's a freshly created file, don't annoy them yet
+      if (!freshlyCreatedFile && !unusedVariables.isEmpty()) {
         throw new IllegalArgumentException("Unused values %s found in the [%s] template. If it's acceptable for the variable to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
                                                                                                                                                                                             .sorted()
                                                                                                                                                                                             .toList(),

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -15,6 +15,7 @@
  */
 package org.primeframework.mvc.test;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +58,30 @@ public class BodyToolsTest {
   }
 
   @Test
+  public void processTemplateWithMap_new_file() throws Exception {
+    // if the file was just created, don't complain about unused variables.
+
+    Path newFile = Paths.get("src/test/web/templates/new_file.ftl");
+    try {
+      // arrange
+      DetectionMap values = new DetectionMap();
+      values.putAll(Map.of("message", "howdy", "othervariable", "value"));
+
+      // act
+      String result = BodyTools.processTemplateWithMap(newFile,
+                                                       values);
+
+      // assert
+      assertEquals(result,
+                   "{\"prime-mvc-auto-generated\": true}");
+    } finally {
+      if (newFile.toFile().exists()) {
+        newFile.toFile().delete();
+      }
+    }
+  }
+
+  @Test
   public void processTemplateWithMap_optional_variable_unused() throws Exception {
     // arrange
     DetectionMap values = new DetectionMap();
@@ -95,8 +120,7 @@ public class BodyToolsTest {
     // act + assert
     try {
       BodyTools.processTemplateWithMap(Paths.get("src/test/web/templates/echo.ftl"),
-                                       values
-      );
+                                       values);
       fail("Expected an exception");
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,


### PR DESCRIPTION
https://github.com/prime-framework/prime-mvc/pull/97 added a cool new feature, but it gets in the way when a file is freshly generated.