### PR TITLE
Add an option to add a header with a nullable value.

### DIFF
--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -1558,6 +1558,23 @@ public class GlobalTest extends PrimeBaseTest {
   }
 
   @Test
+  public void headers_withHeaderIfPresent() throws IOException {
+    // Null value should not add the header
+    simulator.test("/header-values")
+             .withHeaderIfPresent("foo", null)
+             .get()
+             .assertStatusCode(200)
+             .assertJSONValuesAt("/foo", null);
+
+    // Non-null value should add the header
+    simulator.test("/header-values")
+             .withHeaderIfPresent("foo", "bar")
+             .get()
+             .assertStatusCode(200)
+             .assertJSONValuesAt("/foo", List.of("bar"));
+  }
+
+  @Test
   public void dpopHeader() throws IOException {
     // Make sure DPoPProofProvider gets invoked with proper values
     // (a real DPoPProofProvider would generate a signed JWT)

--- a/src/test/java/org/primeframework/mvc/test/RequestBuilder.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestBuilder.java
@@ -789,6 +789,21 @@ public class RequestBuilder {
   }
 
   /**
+   * Adds a header to the request only if the value is non-null. If the value is null, this method is a no-op.
+   * Follows the same pattern as {@link #withSingleHeader(String, String)}, it will replace if called sequentially
+   *
+   * @param name  The name of the header.
+   * @param value The value of the header, or {@code null} to skip adding the header.
+   * @return This.
+   */
+  public RequestBuilder withHeaderIfPresent(String name, String value) {
+    if (value != null) {
+      request.setHeader(name, value);
+    }
+    return this;
+  }
+
+  /**
    * Add a single URL query string parameter.
    *
    * @param name  the name of the parameter.


### PR DESCRIPTION
Looking to add another helper method to the RequestBuilder that takes a header value or doesn't actually add the header to the request if it is null. This makes it easier to feed different states in-line to test different header profiles.