### PR TITLE
Add additional assertion methods to check for specific field errors

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.10.0-{integration}", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.10.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.9.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.10.0-{integration}", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.9.1</version>
+  <version>5.10.0-{integration}</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.10.0-{integration}</version>
+  <version>5.10.0</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/prime-mvc.iml
+++ b/prime-mvc.iml
@@ -16,315 +16,315 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/json-patch/1.13.0/json-patch-1.13.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/inject/guice/6.0.0/guice-6.0.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/google/inject/guice/6.0.0/guice-6.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/inject/guice/6.0.0/guice-6.0.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/google/inject/guice/6.0.0/guice-6.0.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/javax/inject/javax.inject/1/javax.inject-1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/javax/inject/javax.inject/1.0.0/javax.inject-1.0.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/javax/inject/javax.inject/1/javax.inject-1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/jakarta/inject/jakarta.inject-api/2.0.1/jakarta.inject-api-2.0.1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/dropwizard/metrics/metrics-core/3.2.6/metrics-core-3.2.6-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/fusionauth-jwt/6.0.0/fusionauth-jwt-6.0.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/fusionauth/fusionauth-jwt/6.0.0/fusionauth-jwt-6.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/fusionauth-jwt/6.0.0/fusionauth-jwt-6.0.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/fusionauth/fusionauth-jwt/6.0.0/fusionauth-jwt-6.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.15.4/jackson-databind-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.15.4/jackson-annotations-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.15.4/jackson-core-2.15.4-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/1.4.1/java-http-1.4.1.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/fusionauth/java-http/1.4.1/java-http-1.4.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/io/fusionauth/java-http/1.4.1/java-http-1.4.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/io/fusionauth/java-http/1.4.1/java-http-1.4.1-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/freemarker/freemarker/2.3.32/freemarker-2.3.32.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/freemarker/freemarker/2.3.32/freemarker-2.3.32-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/freemarker/freemarker/2.3.32/freemarker-2.3.32-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.5.0/asm-9.5.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/ow2/asm/asm/9.5.0/asm-9.5.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/ow2/asm/asm/9.5.0/asm-9.5.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/ow2/asm/asm/9.5.0/asm-9.5.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/2.0.15/slf4j-api-2.0.15.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/slf4j/slf4j-api/2.0.15/slf4j-api-2.0.15.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/slf4j/slf4j-api/2.0.15/slf4j-api-2.0.15-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/slf4j/slf4j-api/2.0.15/slf4j-api-2.0.15-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/easymock/easymock/5.2.0/easymock-5.2.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/easymock/easymock/5.2.0/easymock-5.2.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/easymock/easymock/5.2.0/easymock-5.2.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/easymock/easymock/5.2.0/easymock-5.2.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/objenesis/objenesis/3.3.0/objenesis-3.3.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/objenesis/objenesis/3.3/objenesis-3.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/objenesis/objenesis/3.3.0/objenesis-3.3.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/objenesis/objenesis/3.3/objenesis-3.3-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/testng/testng/7.8.0/testng-7.8.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/testng/testng/7.8.0/testng-7.8.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/testng/testng/7.8.0/testng-7.8.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/beust/jcommander/1.82/jcommander-1.82.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/beust/jcommander/1.82.0/jcommander-1.82.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/com/beust/jcommander/1.82/jcommander-1.82-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/webjars/jquery/3.6.1/jquery-3.6.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/webjars/jquery/3.6.1/jquery-3.6.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/webjars/jquery/3.6.1/jquery-3.6.1-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jsoup/jsoup/1.16.2/jsoup-1.16.2.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/jsoup/jsoup/1.16.2/jsoup-1.16.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/jsoup/jsoup/1.16.2/jsoup-1.16.2-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/org/jsoup/jsoup/1.16.2/jsoup-1.16.2-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/ch/qos/logback/logback-classic/1.5.13/logback-classic-1.5.13.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/ch/qos/logback/logback-classic/1.5.13/logback-classic-1.5.13.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/ch/qos/logback/logback-classic/1.5.13/logback-classic-1.5.13-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/ch/qos/logback/logback-classic/1.5.13/logback-classic-1.5.13-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="TEST">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/ch/qos/logback/logback-core/1.5.13/logback-core-1.5.13.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/ch/qos/logback/logback-core/1.5.13/logback-core-1.5.13.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/ch/qos/logback/logback-core/1.5.13/logback-core-1.5.13-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/ch/qos/logback/logback-core/1.5.13/logback-core-1.5.13-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/jackson-coreutils/2.0.0/jackson-coreutils-2.0.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/msg-simple/1.2.0/msg-simple-1.2.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/btf/1.3.0/btf-1.3.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/btf/1.3.0/btf-1.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/github/java-json-tools/btf/1.3.0/btf-1.3.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/github/java-json-tools/btf/1.3.0/btf-1.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/aopalliance/aopalliance/1.0.0/aopalliance-1.0.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.m2/repository/aopalliance/aopalliance/1.0/aopalliance-1.0-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/guava/32.1.2-jre/guava-32.1.2-jre-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/failureaccess/1.0.1/failureaccess-1.0.1-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/guava/listenablefuture/9999.0.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0.0-empty-to-avoid-conflict-with-guava.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/guava/listenablefuture/9999.0.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0.0-empty-to-avoid-conflict-with-guava.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -333,33 +333,33 @@
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/org/checkerframework/checker-qual/3.33.0/checker-qual-3.33.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/errorprone/error_prone_annotations/2.18.0/error_prone_annotations-2.18.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" scope="RUNTIME">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/j2objc/j2objc-annotations/2.8.0/j2objc-annotations-2.8.0.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/j2objc/j2objc-annotations/2.8.0/j2objc-annotations-2.8.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/google/j2objc/j2objc-annotations/2.8.0/j2objc-annotations-2.8.0-src.jar!/" />
+          <root url="jar://$USER_HOME$/.cache/savant/com/google/j2objc/j2objc-annotations/2.8.0/j2objc-annotations-2.8.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/test/java/org/example/action/FieldMessageAction.java
+++ b/src/test/java/org/example/action/FieldMessageAction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022-2024, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.example.action;
+
+import com.google.inject.Inject;
+import org.primeframework.mvc.action.annotation.Action;
+import org.primeframework.mvc.action.result.annotation.Status;
+import org.primeframework.mvc.message.MessageStore;
+import org.primeframework.mvc.message.MessageType;
+import org.primeframework.mvc.message.SimpleFieldMessage;
+import org.primeframework.mvc.message.SimpleMessage;
+import org.primeframework.mvc.message.l10n.MessageProvider;
+
+@Action
+@Status
+public class FieldMessageAction {
+  private final MessageProvider messageProvider;
+
+  private final MessageStore messageStore;
+
+  @Inject
+  public FieldMessageAction(MessageProvider messageProvider, MessageStore messageStore) {
+    this.messageProvider = messageProvider;
+    this.messageStore = messageStore;
+  }
+
+  public String get() {
+    messageStore.add(new SimpleFieldMessage(MessageType.INFO, "foo", "[INFO]foo", messageProvider.getMessage("[INFO]", "foo")));
+    messageStore.add(new SimpleFieldMessage(MessageType.WARNING, "bar", "[WARNING]bar", messageProvider.getMessage("[WARNING]", "bar")));
+    messageStore.add(new SimpleFieldMessage(MessageType.ERROR, "baz", "[ERROR]baz",  messageProvider.getMessage("[ERROR]", "baz")));
+    return "success";
+  }
+}

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -15,7 +15,6 @@
  */
 package org.primeframework.mvc;
 
-import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +49,6 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import freemarker.template.Configuration;
-import io.fusionauth.http.HTTPMethod;
 import io.fusionauth.http.HTTPValues.Headers;
 import io.fusionauth.http.HTTPValues.Methods;
 import org.example.action.JwtAuthorizedAction;
@@ -81,6 +79,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.FileAssert.fail;
@@ -930,6 +929,19 @@ public class GlobalTest extends PrimeBaseTest {
              .get()
              .assertStatusCode(200)
              .assertBodyContains("large FTL");
+  }
+
+  @Test
+  public void get_fieldMessage() throws Exception {
+    test.simulate(() -> simulator.test("/field-message")
+                                 .get()
+                                 .assertStatusCode(200)
+                                 .assertFieldHasNoErrors("foo")
+                                 .assertFieldHasNoErrors("bar")
+                                 .custom(r -> assertThrows(AssertionError.class, () -> r.assertFieldHasNoErrors("baz")))
+                                 .assertFieldHasErrorMessage("baz", "baz has an error")
+                                 .assertFieldHasErrorMessageFromKey("baz", "[ERROR]", "baz")
+                                 .assertFieldHasErrorCode("baz", "[ERROR]baz"));
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -914,7 +914,7 @@ public class RequestResult {
   /**
    * Verifies that there are no error messages associated with a specified field in the message store.
    *
-   * @param field The field name.
+   * @param field The field name. No assertion error will be thrown if the field does not exist.
    * @return This.
    */
   public RequestResult assertFieldHasNoErrors(String field) {

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -15,30 +15,6 @@
  */
 package org.primeframework.mvc.test;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -64,21 +40,23 @@ import org.primeframework.mvc.action.ActionInvocation;
 import org.primeframework.mvc.action.ActionInvocationStore;
 import org.primeframework.mvc.action.ActionMapper;
 import org.primeframework.mvc.http.HTTPObjectsHolder;
-import org.primeframework.mvc.message.FieldMessage;
-import org.primeframework.mvc.message.Message;
-import org.primeframework.mvc.message.MessageType;
-import org.primeframework.mvc.message.SimpleFieldMessage;
-import org.primeframework.mvc.message.SimpleMessage;
-import org.primeframework.mvc.message.TestMessageObserver;
+import org.primeframework.mvc.message.*;
 import org.primeframework.mvc.message.l10n.MessageProvider;
 import org.primeframework.mvc.message.l10n.MissingMessageException;
 import org.primeframework.mvc.message.scope.CookieFlashScope;
 import org.primeframework.mvc.security.Encryptor;
-import org.primeframework.mvc.util.CookieTools;
-import org.primeframework.mvc.util.QueryStringBuilder;
-import org.primeframework.mvc.util.QueryStringTools;
-import org.primeframework.mvc.util.ThrowingFunction;
-import org.primeframework.mvc.util.ThrowingRunnable;
+import org.primeframework.mvc.util.*;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import static java.util.Arrays.asList;
 import static org.primeframework.mvc.message.TestMessageObserver.ObserverMessageStoreId;
 
@@ -503,6 +481,74 @@ public class RequestResult {
     }
 
     return this;
+  }
+
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public RequestResult assertFieldHasNoErrors(String field) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+    throw new AssertionError(sb);
+  }
+
+  public RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
+    return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
+  }
+
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public RequestResult assertFieldHasErrorCode(String field, String code) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
+    }
+
+    if (errorMessages.stream()
+            .anyMatch(fieldMessage -> code.equals(fieldMessage.getCode()))) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error code for the %s field.\n".formatted(field));
+    sb.append("\nYou asserted the field had the following error code:\n");
+    sb.append(code);
+    sb.append("\n\nThe field contains the following error codes:\n");
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+
+    throw new AssertionError(sb);
+  }
+
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public RequestResult assertFieldHasErrorMessage(String field, String message) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
+    }
+    if (errorMessages.stream()
+            .anyMatch(fieldMessage -> fieldMessage instanceof SimpleFieldMessage simpleFieldMessage
+                    && message.equals(simpleFieldMessage.message))) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error message for the %s field.\n".formatted(field));
+    sb.append("\nYou asserted the field had the following error message:\n");
+    sb.append(message);
+    sb.append("\n\nThe field contains the following error messages:\n");
+    errorMessages.stream().filter(SimpleFieldMessage.class::isInstance).map(m -> ((SimpleFieldMessage) m).message)
+            .forEach(m -> sb.append(m + "\n"));
+
+    throw new AssertionError(sb);
   }
 
   /**

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -15,8 +15,8 @@
  */
 package org.primeframework.mvc.test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -558,7 +558,7 @@ public class RequestResult {
   }
 
   /**
-   * Verifies that there are no error messages associated with a specified field in the method store.
+   * Verifies that there are no error messages associated with a specified field in the message store.
    *
    * @param field The field name.
    * @return This.

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -483,25 +483,13 @@ public class RequestResult {
     return this;
   }
 
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public RequestResult assertFieldHasNoErrors(String field) {
-    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
-    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
-            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
-
-    if (errorMessages.isEmpty()) {
-      return this;
-    }
-
-    StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
-    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
-    throw new AssertionError(sb);
-  }
-
-  public RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
-    return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
-  }
-
+  /**
+   * Verifies that a specific error code exists for a field.
+   *
+   * @param field The field name.
+   * @param code  The error code.
+   * @return This.
+   */
   @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
   public RequestResult assertFieldHasErrorCode(String field, String code) {
     Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
@@ -526,6 +514,12 @@ public class RequestResult {
     throw new AssertionError(sb);
   }
 
+  /**
+   * Verifies that a specific error message exists for a field.
+   * @param field The field name.
+   * @param message The error message.
+   * @return This.
+   */
   @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
   public RequestResult assertFieldHasErrorMessage(String field, String message) {
     Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
@@ -548,6 +542,39 @@ public class RequestResult {
     errorMessages.stream().filter(SimpleFieldMessage.class::isInstance).map(m -> ((SimpleFieldMessage) m).message)
             .forEach(m -> sb.append(m + "\n"));
 
+    throw new AssertionError(sb);
+  }
+
+  /**
+   * Verifies that a specific error message exists for a field.
+   *
+   * @param field  The field name.
+   * @param key    The message key.
+   * @param values The replacement values.
+   * @return This.
+   */
+  public RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
+    return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
+  }
+
+  /**
+   * Verifies that there are no error messages associated with a specified field in the method store.
+   *
+   * @param field The field name.
+   * @return This.
+   */
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public RequestResult assertFieldHasNoErrors(String field) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
     throw new AssertionError(sb);
   }
 

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -15,8 +15,32 @@
  */
 package org.primeframework.mvc.test;
 
-import com.fasterxml.jackson.core.util.DefaultIndenter;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -40,23 +64,21 @@ import org.primeframework.mvc.action.ActionInvocation;
 import org.primeframework.mvc.action.ActionInvocationStore;
 import org.primeframework.mvc.action.ActionMapper;
 import org.primeframework.mvc.http.HTTPObjectsHolder;
-import org.primeframework.mvc.message.*;
+import org.primeframework.mvc.message.FieldMessage;
+import org.primeframework.mvc.message.Message;
+import org.primeframework.mvc.message.MessageType;
+import org.primeframework.mvc.message.SimpleFieldMessage;
+import org.primeframework.mvc.message.SimpleMessage;
+import org.primeframework.mvc.message.TestMessageObserver;
 import org.primeframework.mvc.message.l10n.MessageProvider;
 import org.primeframework.mvc.message.l10n.MissingMessageException;
 import org.primeframework.mvc.message.scope.CookieFlashScope;
 import org.primeframework.mvc.security.Encryptor;
-import org.primeframework.mvc.util.*;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import org.primeframework.mvc.util.CookieTools;
+import org.primeframework.mvc.util.QueryStringBuilder;
+import org.primeframework.mvc.util.QueryStringTools;
+import org.primeframework.mvc.util.ThrowingFunction;
+import org.primeframework.mvc.util.ThrowingRunnable;
 import static java.util.Arrays.asList;
 import static org.primeframework.mvc.message.TestMessageObserver.ObserverMessageStoreId;
 
@@ -484,101 +506,6 @@ public class RequestResult {
   }
 
   /**
-   * Verifies that a specific error code exists for a field.
-   *
-   * @param field The field name.
-   * @param code  The error code.
-   * @return This.
-   */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public RequestResult assertFieldHasErrorCode(String field, String code) {
-    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
-    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
-            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
-
-    if (errorMessages.isEmpty()) {
-      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
-    }
-
-    if (errorMessages.stream()
-            .anyMatch(fieldMessage -> code.equals(fieldMessage.getCode()))) {
-      return this;
-    }
-
-    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error code for the %s field.\n".formatted(field));
-    sb.append("\nYou asserted the field had the following error code:\n");
-    sb.append(code);
-    sb.append("\n\nThe field contains the following error codes:\n");
-    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
-
-    throw new AssertionError(sb);
-  }
-
-  /**
-   * Verifies that a specific error message exists for a field.
-   * @param field The field name.
-   * @param message The error message.
-   * @return This.
-   */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public RequestResult assertFieldHasErrorMessage(String field, String message) {
-    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
-    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
-            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
-
-    if (errorMessages.isEmpty()) {
-      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
-    }
-    if (errorMessages.stream()
-            .anyMatch(fieldMessage -> fieldMessage instanceof SimpleFieldMessage simpleFieldMessage
-                    && message.equals(simpleFieldMessage.message))) {
-      return this;
-    }
-
-    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error message for the %s field.\n".formatted(field));
-    sb.append("\nYou asserted the field had the following error message:\n");
-    sb.append(message);
-    sb.append("\n\nThe field contains the following error messages:\n");
-    errorMessages.stream().filter(SimpleFieldMessage.class::isInstance).map(m -> ((SimpleFieldMessage) m).message)
-            .forEach(m -> sb.append(m + "\n"));
-
-    throw new AssertionError(sb);
-  }
-
-  /**
-   * Verifies that a specific error message exists for a field.
-   *
-   * @param field  The field name.
-   * @param key    The message key.
-   * @param values The replacement values.
-   * @return This.
-   */
-  public RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
-    return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
-  }
-
-  /**
-   * Verifies that there are no error messages associated with a specified field in the message store.
-   *
-   * @param field The field name.
-   * @return This.
-   */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public RequestResult assertFieldHasNoErrors(String field) {
-    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
-    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
-            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
-
-    if (errorMessages.isEmpty()) {
-      return this;
-    }
-
-    StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
-    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
-    throw new AssertionError(sb);
-  }
-
-  /**
    * Verifies that the system has general errors. This doesn't assert the error itself, just that the general error code.
    *
    * @param messageCodes The name of the error code(s). Not the fully rendered message(s)
@@ -909,6 +836,101 @@ public class RequestResult {
     }
 
     return this;
+  }
+
+  /**
+   * Verifies that a specific error code exists for a field.
+   *
+   * @param field The field name.
+   * @param code  The error code.
+   * @return This.
+   */
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorCode(String field, String code) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
+    }
+
+    if (errorMessages.stream()
+            .anyMatch(fieldMessage -> code.equals(fieldMessage.getCode()))) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error code for the %s field.\n".formatted(field));
+    sb.append("\nYou asserted the field had the following error code:\n");
+    sb.append(code);
+    sb.append("\n\nThe field contains the following error codes:\n");
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+
+    throw new AssertionError(sb);
+  }
+
+  /**
+   * Verifies that a specific error message exists for a field.
+   * @param field The field name.
+   * @param message The error message.
+   * @return This.
+   */
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorMessage(String field, String message) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      throw new AssertionError("The MessageStore does not contain any error messages for the field [" + field + "]");
+    }
+    if (errorMessages.stream()
+            .anyMatch(fieldMessage -> fieldMessage instanceof SimpleFieldMessage simpleFieldMessage
+                    && message.equals(simpleFieldMessage.message))) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore does not contain the specified error message for the %s field.\n".formatted(field));
+    sb.append("\nYou asserted the field had the following error message:\n");
+    sb.append(message);
+    sb.append("\n\nThe field contains the following error messages:\n");
+    errorMessages.stream().filter(SimpleFieldMessage.class::isInstance).map(m -> ((SimpleFieldMessage) m).message)
+            .forEach(m -> sb.append(m + "\n"));
+
+    throw new AssertionError(sb);
+  }
+
+  /**
+   * Verifies that a specific error message exists for a field.
+   *
+   * @param field  The field name.
+   * @param key    The message key.
+   * @param values The replacement values.
+   * @return This.
+   */
+  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
+    return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
+  }
+
+  /**
+   * Verifies that there are no error messages associated with a specified field in the message store.
+   *
+   * @param field The field name.
+   * @return This.
+   */
+  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
+  public org.primeframework.mvc.test.RequestResult assertFieldHasNoErrors(String field) {
+    Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
+    List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
+            .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
+
+    if (errorMessages.isEmpty()) {
+      return this;
+    }
+
+    StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+    throw new AssertionError(sb);
   }
 
   /**

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -871,6 +871,7 @@ public class RequestResult {
 
   /**
    * Verifies that a specific error message exists for a field.
+   * 
    * @param field The field name.
    * @param message The error message.
    * @return This.

--- a/src/test/java/org/primeframework/mvc/test/RequestResult.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestResult.java
@@ -845,8 +845,7 @@ public class RequestResult {
    * @param code  The error code.
    * @return This.
    */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorCode(String field, String code) {
+  public RequestResult assertFieldHasErrorCode(String field, String code) {
     Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
     List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
             .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
@@ -864,7 +863,7 @@ public class RequestResult {
     sb.append("\nYou asserted the field had the following error code:\n");
     sb.append(code);
     sb.append("\n\nThe field contains the following error codes:\n");
-    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m).append("\n"));
 
     throw new AssertionError(sb);
   }
@@ -876,8 +875,7 @@ public class RequestResult {
    * @param message The error message.
    * @return This.
    */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorMessage(String field, String message) {
+  public RequestResult assertFieldHasErrorMessage(String field, String message) {
     Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
     List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
             .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
@@ -896,7 +894,7 @@ public class RequestResult {
     sb.append(message);
     sb.append("\n\nThe field contains the following error messages:\n");
     errorMessages.stream().filter(SimpleFieldMessage.class::isInstance).map(m -> ((SimpleFieldMessage) m).message)
-            .forEach(m -> sb.append(m + "\n"));
+            .forEach(m -> sb.append(m).append("\n"));
 
     throw new AssertionError(sb);
   }
@@ -909,7 +907,7 @@ public class RequestResult {
    * @param values The replacement values.
    * @return This.
    */
-  public org.primeframework.mvc.test.RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
+  public RequestResult assertFieldHasErrorMessageFromKey(String field, String key, Object... values) {
     return assertFieldHasErrorMessage(field, getMessageProviderToLookupMessages().getMessage(key, values));
   }
 
@@ -919,8 +917,7 @@ public class RequestResult {
    * @param field The field name.
    * @return This.
    */
-  @SuppressWarnings("StringConcatenationInsideStringBufferAppend")
-  public org.primeframework.mvc.test.RequestResult assertFieldHasNoErrors(String field) {
+  public RequestResult assertFieldHasNoErrors(String field) {
     Map<String, List<FieldMessage>> msgs = messageObserver.getFieldMessages();
     List<FieldMessage> errorMessages = msgs.getOrDefault(field, List.of()).stream()
             .filter(fieldMessage -> fieldMessage.getType() == MessageType.ERROR).toList();
@@ -930,7 +927,7 @@ public class RequestResult {
     }
 
     StringBuilder sb = new StringBuilder("The MessageStore contains the following error codes for field %s:\n".formatted(field));
-    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m + "\n"));
+    errorMessages.stream().map(Message::getCode).forEach(m -> sb.append(m).append("\n"));
     throw new AssertionError(sb);
   }
 

--- a/src/test/web/messages/field-message.properties
+++ b/src/test/web/messages/field-message.properties
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026, Inversoft Inc., All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+#
+[INFO]=%s has info
+[WARNING]=%s has a warning
+[ERROR]=%s has an error


### PR DESCRIPTION
### Problem 
`RequestResult` has several assertion methods to check for field errors, but none of them allow checking whether a specific field has a specific error. 

### Solution
Add methods to check for a specific error message or code on a given field, and a method to assert that a field has no errors. 