### PR TITLE
Update patch handling for final request fields

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.10.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.11.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/src/main/java/org/primeframework/mvc/content/json/JacksonPatchContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/JacksonPatchContentHandler.java
@@ -16,6 +16,9 @@
 package org.primeframework.mvc.content.json;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +36,7 @@ import org.primeframework.mvc.message.MessageType;
 import org.primeframework.mvc.message.SimpleMessage;
 import org.primeframework.mvc.message.l10n.MessageProvider;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
+import org.primeframework.mvc.util.ReflectionUtils;
 import org.primeframework.mvc.validation.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,13 +74,48 @@ public class JacksonPatchContentHandler extends BaseJacksonContentHandler {
 
     // Build the patch from the incoming request body
     Patch patch = objectMapper.readerFor(contentType.equals("application/json-patch+json")
-                                  ? JsonPatch.class
-                                  : JsonMergePatch.class)
+                                             ? JsonPatch.class
+                                             : JsonMergePatch.class)
                               .readValue(request.getInputStream());
 
     // Patch the current object
-    JsonNode patched = patch.apply(objectMapper.valueToTree(currentValue));
+    JsonNode source = objectMapper.valueToTree(currentValue);
+    JsonNode patched = patch.apply(source);
+
+    // Deserialize into a fully patched request object first.
+    // This stays with the patch behavior we were using before and we can
+    // continue assigning this object on the request for non-final members.
     Object patchedObject = objectMapper.readerFor(requestMember.type).readValue(patched);
+
+    // For non-final request members we keep the original assignment behavior.
+    // For final request members, reassignment is not possible, so we copy
+    // patched object state onto the existing instance instead. readerForUpdating couldn't
+    // be used because values that had been removed from the source were left intact in
+    // the target object (they would need to be set to null, instead of removed, if we wanted
+    // readerForUpdating to work correctly)
+    if (isFinalRequestMember(action.getClass(), requestMember.name)) {
+      copyFields(patchedObject, currentValue);
+      return;
+    }
+
     expressionEvaluator.setValue(requestMember.name, action, patchedObject);
+  }
+
+  private void copyFields(Object source, Object target) throws IOException {
+    try {
+      Map<String, Field> fields = ReflectionUtils.findFields(source.getClass());
+      for (Field field : fields.values()) {
+        if (!Modifier.isFinal(field.getModifiers())) {
+          field.set(target, field.get(source));
+        }
+      }
+    } catch (IllegalAccessException e) {
+      throw new IOException("Unable to copy patched object to current value", e);
+    }
+  }
+
+  private boolean isFinalRequestMember(Class<?> actionClass, String memberName) {
+    Field field = ReflectionUtils.findFields(actionClass).get(memberName);
+    return field != null && Modifier.isFinal(field.getModifiers());
   }
 }

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonPatchContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonPatchContentHandlerTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package org.primeframework.mvc.content.json;
+
+import java.io.ByteArrayInputStream;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fusionauth.http.HTTPMethod;
+import io.fusionauth.http.server.HTTPRequest;
+import org.example.action.patch.PatchActionRequest;
+import org.example.action.patch.PatchActionRequest.CoolObject;
+import org.example.action.patch.TestAction;
+import org.primeframework.mvc.PrimeBaseTest;
+import org.primeframework.mvc.action.ActionInvocation;
+import org.primeframework.mvc.action.ActionInvocationStore;
+import org.primeframework.mvc.action.ExecuteMethodConfiguration;
+import org.primeframework.mvc.action.config.ActionConfiguration;
+import org.primeframework.mvc.content.json.JacksonActionConfiguration.RequestMember;
+import org.primeframework.mvc.content.json.annotation.JSONPatch;
+import org.primeframework.mvc.message.MessageStore;
+import org.primeframework.mvc.message.l10n.MessageProvider;
+import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
+import com.google.inject.Inject;
+import org.testng.annotations.Test;
+import static org.easymock.EasyMock.createStrictMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Focused handler-level regression tests for PATCH requests when the action has a final @JSONRequest field.
+ *
+ * We intentionally bypass full action scanning and construct only the configuration needed for this handler path.
+ */
+public class JacksonPatchContentHandlerTest extends PrimeBaseTest {
+  @Inject public ExpressionEvaluator expressionEvaluator;
+
+  @Test
+  public void json_patch_remove_nulls_removed_field_on_final_request_object() throws Exception {
+    FinalPatchAction action = new FinalPatchAction();
+    PatchActionRequest originalRequest = action.request;
+    action.request.data = new CoolObject();
+    action.request.data.email = "jim@example.com";
+    action.request.data.name = "Jim Bob";
+
+    ActionInvocationStore store = buildStore(action, patchRequestMember());
+    HTTPRequest request = patchRequest("""
+        [
+          {
+            "op": "remove",
+            "path": "/data/email"
+          }
+        ]
+        """, "application/json-patch+json");
+
+    MessageProvider messageProvider = createStrictMock(MessageProvider.class);
+    MessageStore messageStore = createStrictMock(MessageStore.class);
+    replay(messageProvider, messageStore);
+
+    JacksonPatchContentHandler handler = new JacksonPatchContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore);
+    handler.handle();
+
+    // Confirms the final request field was not reassigned.
+    assertSame(action.request, originalRequest);
+    assertNull(action.request.data.email);
+    assertEquals(action.request.data.name, "Jim Bob");
+
+    verify(store, messageProvider, messageStore);
+  }
+
+  @Test
+  public void merge_patch_null_removes_field_on_final_request_object() throws Exception {
+    FinalPatchAction action = new FinalPatchAction();
+    PatchActionRequest originalRequest = action.request;
+    action.request.data = new CoolObject();
+    action.request.data.email = "jim@example.com";
+    action.request.data.name = "Jim Bob";
+
+    ActionInvocationStore store = buildStore(action, patchRequestMember());
+    HTTPRequest request = patchRequest("""
+        {
+          "data": {
+            "email": null
+          }
+        }
+        """, "application/merge-patch+json");
+
+    MessageProvider messageProvider = createStrictMock(MessageProvider.class);
+    MessageStore messageStore = createStrictMock(MessageStore.class);
+    replay(messageProvider, messageStore);
+
+    JacksonPatchContentHandler handler = new JacksonPatchContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore);
+    handler.handle();
+
+    // Confirms the final request field was not reassigned.
+    assertSame(action.request, originalRequest);
+    assertNull(action.request.data.email);
+    assertEquals(action.request.data.name, "Jim Bob");
+
+    verify(store, messageProvider, messageStore);
+  }
+
+  private ActionInvocationStore buildStore(Object action, RequestMember requestMember) {
+    Map<HTTPMethod, RequestMember> requestMembers = new HashMap<>();
+    requestMembers.put(HTTPMethod.PATCH, requestMember);
+
+    Map<Class<?>, Object> additionalConfig = new HashMap<>();
+    additionalConfig.put(JacksonActionConfiguration.class, new JacksonActionConfiguration(requestMembers, null, null));
+
+    // Use TestAction for ActionConfiguration metadata so @Action and execute-method requirements are satisfied.
+    // The ActionInvocation still uses the local FinalPatchAction instance to exercise final-field behavior.
+    ActionConfiguration configuration = new ActionConfiguration(TestAction.class,
+                                                                false,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                Collections.emptyList(),
+                                                                null,
+                                                                additionalConfig,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null,
+                                                                null);
+
+    ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);
+    expect(store.getCurrent()).andReturn(new ActionInvocation(action, new ExecuteMethodConfiguration(HTTPMethod.PATCH, null, null), "/patch/test", null, configuration));
+    replay(store);
+    return store;
+  }
+
+  private HTTPRequest patchRequest(String body, String contentType) {
+    byte[] bytes = body.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    HTTPRequest request = new HTTPRequest();
+    request.setInputStream(new ByteArrayInputStream(bytes));
+    request.setContentLength((long) bytes.length);
+    request.setContentType(contentType);
+    return request;
+  }
+
+  private RequestMember patchRequestMember() {
+    // Stub annotation instance to enable PATCH handling for this request member.
+    return new RequestMember("request", PatchActionRequest.class, new TestJSONPatch());
+  }
+
+  // Must be public static to allow reflective field access during expression evaluation.
+  // Action with final request field.
+  public static class FinalPatchAction {
+    public final PatchActionRequest request = new PatchActionRequest();
+  }
+
+  // Needed to provide a @JSONPatch annotation instance for the request member configuration.
+  private static class TestJSONPatch implements JSONPatch {
+    @Override
+    public Class<? extends Annotation> annotationType() {
+      return JSONPatch.class;
+    }
+  }
+}


### PR DESCRIPTION
Problem:
If an action's request field set as final, when PrimeMVC handles json-patch+json and merge-patch+json after performing the patch it replaces the request field with the patched object which fails because the field is final.

Solution:
If the field is final, it is now being merged in-place to avoid the illegal access exception.