### PR TITLE
Change request simulator code to set cookies the way the implementation does

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.10.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.10.1", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
+++ b/src/test/java/org/primeframework/mvc/BrowserSessionTest.java
@@ -15,13 +15,14 @@
  */
 package org.primeframework.mvc;
 
-import java.util.Base64;
-
+import io.fusionauth.http.Cookie;
 import org.example.domain.User;
 import org.primeframework.mvc.security.CBCCipherProvider;
 import org.primeframework.mvc.security.DefaultEncryptor;
 import org.primeframework.mvc.security.Encryptor;
 import org.testng.annotations.Test;
+
+import java.util.Base64;
 
 /**
  * This class tests managed JSON cookies.
@@ -29,74 +30,74 @@ import org.testng.annotations.Test;
  * @author Brian Pontarelli
  */
 public class BrowserSessionTest extends PrimeBaseTest {
-  @Test
-  public void not_encrypted_cookie() throws Exception {
-    // Scenario:
-    // 1) Browser visits the /browser-session/decrypted page
-    // 2) DecryptedAction sets the cookie value to a non-encrypted value
-    // 3) SecondAction, which expects an encrypted cookie, will not be able to decrypt an un-encrypted cookie since
-    //    encryption is required.
+    @Test
+    public void not_encrypted_cookie() throws Exception {
+        // Scenario:
+        // 1) Browser visits the /browser-session/decrypted page
+        // 2) DecryptedAction sets the cookie value to a non-encrypted value
+        // 3) SecondAction, which expects an encrypted cookie, will not be able to decrypt an un-encrypted cookie since
+        //    encryption is required.
 
-    test.simulate(() -> simulator.test("/browser-session/decrypted")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/browser-session/second")
-                                 .assertContainsCookie("user"))
-        .simulate(() -> simulator.test("/browser-session/second")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // decrypted tries to use a non-encrypted cookie
-                                 // to supply a user to SecondAction, which
-                                 // requires an encrypted cookie by virtue of
-                                 // relying on the defaults for @BrowserSession
-                                 .assertBodyContains("The user is missing")
-                                 .assertCookieWasDeleted("user"));
-  }
+        test.simulate(() -> simulator.test("/browser-session/decrypted")
+                        .get()
+                        .assertStatusCode(302)
+                        .assertRedirect("/browser-session/second")
+                        .assertContainsCookie("user"))
+                .simulate(() -> simulator.test("/browser-session/second")
+                        .get()
+                        .assertStatusCode(200)
+                        // decrypted tries to use a non-encrypted cookie
+                        // to supply a user to SecondAction, which
+                        // requires an encrypted cookie by virtue of
+                        // relying on the defaults for @BrowserSession
+                        .assertBodyContains("The user is missing")
+                        .assertCookieWasDeleted("user"));
+    }
 
-  @Test
-  public void compatibility() throws Exception {
-    // Scenario:
-    // 1) A cookie using AES/CBC is sent to the page
-    // 2) The cookie decryption will try AES/GCM first and fall back to AES/CBC
+    @Test
+    public void compatibility() throws Exception {
+        // Scenario:
+        // 1) A cookie using AES/CBC is sent to the page
+        // 2) The cookie decryption will try AES/GCM first and fall back to AES/CBC
 
-    // Create a User object, serialize to JSON, encrypt with CBC, base64url-encode
-    var user = new User();
-    user.setName("Brian Pontarelli");
-    byte[] serialized = objectMapper.writeValueAsBytes(user);
-    // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
-    Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
-    byte[] encrypted = cbcEncryptor.encrypt(serialized);
-    String encoded = Base64.getUrlEncoder().encodeToString(encrypted);
+        // Create a User object, serialize to JSON, encrypt with CBC, base64url-encode
+        var user = new User();
+        user.setName("Brian Pontarelli");
+        byte[] serialized = objectMapper.writeValueAsBytes(user);
+        // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
+        Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
+        byte[] encrypted = cbcEncryptor.encrypt(serialized);
+        String encoded = Base64.getUrlEncoder().encodeToString(encrypted);
 
-    test.simulate(() -> simulator.test("/browser-session/second")
-                                 .withCookie("user", encoded)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("The user is Brian Pontarelli")
-                                 .assertContainsCookie("user"));
-  }
+        test.simulate(() -> simulator.test("/browser-session/second")
+                .withCookie(new Cookie("user", encoded))
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("The user is Brian Pontarelli")
+                .assertContainsCookie("user"));
+    }
 
-  @Test
-  public void sessionCookie() throws Exception {
-    test.simulate(() -> simulator.test("/browser-session/first")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/browser-session/second")
-                                 .assertContainsCookie("user"))
-        .simulate(() -> simulator.test("/browser-session/second")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("The user is Brian Pontarelli")
-                                 .assertContainsCookie("user"))
-        .simulate(() -> simulator.test("/browser-session/second")
-                                 .post()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/browser-session/second")
-                                 .assertCookieWasDeleted("user")) // Delete the cookie
-        .simulate(() -> simulator.test("/browser-session/second")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("The user is missing")
-                                 .assertDoesNotContainsCookie("user")); // Should be deleted
-  }
+    @Test
+    public void sessionCookie() throws Exception {
+        test.simulate(() -> simulator.test("/browser-session/first")
+                        .get()
+                        .assertStatusCode(302)
+                        .assertRedirect("/browser-session/second")
+                        .assertContainsCookie("user"))
+                .simulate(() -> simulator.test("/browser-session/second")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("The user is Brian Pontarelli")
+                        .assertContainsCookie("user"))
+                .simulate(() -> simulator.test("/browser-session/second")
+                        .post()
+                        .assertStatusCode(302)
+                        .assertRedirect("/browser-session/second")
+                        .assertCookieWasDeleted("user")) // Delete the cookie
+                .simulate(() -> simulator.test("/browser-session/second")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("The user is missing")
+                        .assertDoesNotContainsCookie("user")); // Should be deleted
+    }
 }

--- a/src/test/java/org/primeframework/mvc/GlobalTest.java
+++ b/src/test/java/org/primeframework/mvc/GlobalTest.java
@@ -15,40 +15,13 @@
  */
 package org.primeframework.mvc;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.net.InetSocketAddress;
-import java.net.Socket;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse.BodySubscribers;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.ResourceBundle;
-import java.util.UUID;
-
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import freemarker.template.Configuration;
+import io.fusionauth.http.Cookie;
 import io.fusionauth.http.HTTPValues.Headers;
 import io.fusionauth.http.HTTPValues.Methods;
 import org.example.action.JwtAuthorizedAction;
@@ -77,10 +50,30 @@ import org.primeframework.mvc.util.URIBuilder;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodySubscribers;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+
+import static org.testng.Assert.*;
 import static org.testng.AssertJUnit.assertFalse;
 import static org.testng.FileAssert.fail;
 
@@ -90,3016 +83,3016 @@ import static org.testng.FileAssert.fail;
  * @author Brian Pontarelli
  */
 public class GlobalTest extends PrimeBaseTest {
-  private Path jsonDir;
+    private Path jsonDir;
 
-  @BeforeClass
-  public void beforeClass() {
-    jsonDir = Path.of("src/test/resources/json");
-  }
+    @BeforeClass
+    public void beforeClass() {
+        jsonDir = Path.of("src/test/resources/json");
+    }
 
-  @Test
-  public void cache_control_disabled() throws Exception {
-    // Disable cache control managed by the result handler.
-    test.simulate(() -> simulator.test("/cache-control-disabled")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderDoesNotContain("Cache-Control"));
-  }
+    @Test
+    public void cache_control_disabled() throws Exception {
+        // Disable cache control managed by the result handler.
+        test.simulate(() -> simulator.test("/cache-control-disabled")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderDoesNotContain("Cache-Control"));
+    }
 
-  @Test
-  public void cache_control_override() throws Exception {
-    // Override the default cache control settings, values are not validated to be valid.
-    test.simulate(() -> simulator.test("/cache-control-override")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-store"));
-  }
+    @Test
+    public void cache_control_override() throws Exception {
+        // Override the default cache control settings, values are not validated to be valid.
+        test.simulate(() -> simulator.test("/cache-control-override")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-store"));
+    }
 
-  @Test
-  public void custom_constraints() throws Exception {
-    // Using @ConstraintOverride on the delete method.
-    test.loginUserWithRole("delete-only")
-        .simulate(() -> simulator.test("/secure")
-                                 .delete()
-                                 .assertStatusCode(200))
+    @Test
+    public void custom_constraints() throws Exception {
+        // Using @ConstraintOverride on the delete method.
+        test.loginUserWithRole("delete-only")
+                .simulate(() -> simulator.test("/secure")
+                        .delete()
+                        .assertStatusCode(200))
 
-        // But fails for put
-        .simulate(() -> simulator.test("/secure")
-                                 .put()
-                                 .assertStatusCode(403));
+                // But fails for put
+                .simulate(() -> simulator.test("/secure")
+                        .put()
+                        .assertStatusCode(403));
 
-    // Using the @ConstraintOverrideMethod
-    test.loginUserWithRole("put-only")
-        .simulate(() -> simulator.test("/secure")
-                                 .put()
-                                 .assertStatusCode(200))
+        // Using the @ConstraintOverrideMethod
+        test.loginUserWithRole("put-only")
+                .simulate(() -> simulator.test("/secure")
+                        .put()
+                        .assertStatusCode(200))
 
-        // But fails for delete
-        .simulate(() -> simulator.test("/secure")
-                                 .delete()
-                                 .assertStatusCode(403));
-  }
+                // But fails for delete
+                .simulate(() -> simulator.test("/secure")
+                        .delete()
+                        .assertStatusCode(403));
+    }
 
-  @Test
-  public void embeddedFormHandling() throws Exception {
-    // Ensure this 'required' parameter for PageOne does not mess up PageTwo which does not have an Id field.
-    test.simulate(() -> simulator.test("/scope/page-one")
-                                 .withURLSegment("IdOnlyForPageOne")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-
-    // Ensure the @FileUpload in the PageOneAction does not mess up PageTwo
-    test.createFile()
-        .simulate(() -> simulator.test("/scope/page-one")
-                                 .withFile("file", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test
-  public void escapePathSegmentsWithWildCard() throws Exception {
-    test.simulate(() -> simulator.test("/escaped-path-segments")
-                                 .withURLSegment("foo bar")
-                                 .withURLSegment("foobar")
-                                 .withURLSegment("foo bar")
-                                 .withURLSegment("foo@bar")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains(
-                                     "Success!",
-                                     "parm=foo bar",
-                                     "theRest=foobar,foo bar,foo@bar"));
-
-    test.simulate(() -> simulator.test("/escaped-path-segments")
-                                 .withURLSegment("<foo>")
-                                 .withURLSegment("foo bar")
-                                 .withURLSegment("foobar")
-                                 .withURLSegment("foo bar")
-                                 .withURLSegment("foo@bar")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains(
-                                     "Success!",
-                                     "parm=&lt;foo&gt;",
-                                     "theRest=foo bar,foobar,foo bar,foo@bar"));
-  }
-
-  @Test
-  public void flash_scope_compatibility() throws Exception {
-    // Use case: MVC is able to decrypt a flash message cookie that was encrypted with legacy methods
-    // Create a SimpleMessage, serialize, encrypt, and encode. The message text is hard-coded here because there is no context to look up the message.
-    var message = new SimpleMessage(MessageType.INFO, "[FlashScopeMessageKey]", "This is a message!");
-    // Serialize List<Message>
-    var serialized = objectMapper.writeValueAsBytes(List.of(message));
-    // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
-    Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
-    var encrypted = cbcEncryptor.encrypt(serialized);
-    var encoded = Base64.getUrlEncoder().encodeToString(encrypted);
-
-    simulator.test("/flash-scope/")
-             .withCookie(configuration.messageFlashScopeCookieName(), encoded)
-             .get()
-             .assertStatusCode(200)
-             .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
-             .assertBodyContainsMessagesFromKey("[FlashScopeMessageKey]")
-             .assertBody("""
-                             This is an index page.
-                             
-                               Info:This is a message!
-                             
-                             """)
-    ;
-  }
-
-  @Test
-  public void follow_meta_refresh() throws Exception {
-    // use upper case Refresh and URL, and lower case refresh and url
-    test.forEach("lc", "uc")
-        .test(param -> test
-            .simulate(() -> simulator
-                .test("/meta/refresh")
-                .withURLParameter("test", param)
+    @Test
+    public void embeddedFormHandling() throws Exception {
+        // Ensure this 'required' parameter for PageOne does not mess up PageTwo which does not have an Id field.
+        test.simulate(() -> simulator.test("/scope/page-one")
+                .withURLSegment("IdOnlyForPageOne")
                 .get()
                 .assertStatusCode(200)
-                .assertBodyContains("""
+                .assertHeaderContains("Cache-Control", "no-cache"));
+
+        // Ensure the @FileUpload in the PageOneAction does not mess up PageTwo
+        test.createFile()
+                .simulate(() -> simulator.test("/scope/page-one")
+                        .withFile("file", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test
+    public void escapePathSegmentsWithWildCard() throws Exception {
+        test.simulate(() -> simulator.test("/escaped-path-segments")
+                .withURLSegment("foo bar")
+                .withURLSegment("foobar")
+                .withURLSegment("foo bar")
+                .withURLSegment("foo@bar")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains(
+                        "Success!",
+                        "parm=foo bar",
+                        "theRest=foobar,foo bar,foo@bar"));
+
+        test.simulate(() -> simulator.test("/escaped-path-segments")
+                .withURLSegment("<foo>")
+                .withURLSegment("foo bar")
+                .withURLSegment("foobar")
+                .withURLSegment("foo bar")
+                .withURLSegment("foo@bar")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains(
+                        "Success!",
+                        "parm=&lt;foo&gt;",
+                        "theRest=foo bar,foobar,foo bar,foo@bar"));
+    }
+
+    @Test
+    public void flash_scope_compatibility() throws Exception {
+        // Use case: MVC is able to decrypt a flash message cookie that was encrypted with legacy methods
+        // Create a SimpleMessage, serialize, encrypt, and encode. The message text is hard-coded here because there is no context to look up the message.
+        var message = new SimpleMessage(MessageType.INFO, "[FlashScopeMessageKey]", "This is a message!");
+        // Serialize List<Message>
+        var serialized = objectMapper.writeValueAsBytes(List.of(message));
+        // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
+        Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
+        var encrypted = cbcEncryptor.encrypt(serialized);
+        var encoded = Base64.getUrlEncoder().encodeToString(encrypted);
+
+        simulator.test("/flash-scope/")
+                .withCookie(new Cookie(configuration.messageFlashScopeCookieName(), encoded))
+                .get()
+                .assertStatusCode(200)
+                .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
+                .assertBodyContainsMessagesFromKey("[FlashScopeMessageKey]")
+                .assertBody("""
+                        This is an index page.
+                        
+                          Info:This is a message!
+                        
+                        """)
+        ;
+    }
+
+    @Test
+    public void follow_meta_refresh() throws Exception {
+        // use upper case Refresh and URL, and lower case refresh and url
+        test.forEach("lc", "uc")
+                .test(param -> test
+                        .simulate(() -> simulator
+                                .test("/meta/refresh")
+                                .withURLParameter("test", param)
+                                .get()
+                                .assertStatusCode(200)
+                                .assertBodyContains("""
                                         <meta http-equiv="{refresh}" content="0; {url}=/meta/target">
                                         """
                                         .replace("{refresh}", param.equals("uc") ? "Refresh" : "refresh")
                                         .replace("{url}", param.equals("uc") ? "URL" : "url"))
 
-                .followMetaRefresh(result -> result
+                                .followMetaRefresh(result -> result
+                                        .assertStatusCode(200)
+                                        .assertBody("""
+                                                We made it!
+                                                """)))
+                );
+    }
+
+    @Test
+    public void get() throws Exception {
+        // Not called yet
+        assertEquals(MockMVCWorkflowFinalizer.Called.get(), 0);
+
+        simulator.test("/user/edit")
+                .get()
+                .assertStatusCode(200)
+                // header name is not case-sensitive
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertHeaderContains("cache-control", "no-cache")
+                .assertHeaderDoesNotContain("Potato")
+                .assertBodyFile(Path.of("src/test/resources/html/edit.html"));
+
+        // 1 call! Ah ah ah...
+        assertEquals(MockMVCWorkflowFinalizer.Called.get(), 1);
+
+        EditAction.getCalled = false;
+        simulator.test("/user/edit")
+                .withHeader(Headers.MethodOverride, Methods.GET)
+                .get()
+                .assertStatusCode(200);
+
+        assertTrue(EditAction.getCalled);
+
+        // 2 calls! Ah ah ah...
+        assertEquals(MockMVCWorkflowFinalizer.Called.get(), 2);
+    }
+
+    @Test
+    public void get_ContentTypeOverride() {
+        simulator.test("/content-type-override")
+                .get()
+                .assertStatusCode(200)
+                .assertContentType("application/json+scim");
+
+        // Override from the JSON annotation
+        simulator.test("/content-type-override")
+                .withURLParameter("status", 400)
+                .get()
+                .assertStatusCode(400)
+                .assertContentType("application/json+error");
+    }
+
+    @Test
+    public void get_JSONView() throws Exception {
+        test.simulate(() -> simulator.test("/views/entry/api")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSONFile(jsonDir.resolve("views/entry/entry-api.json")));
+
+        test.simulate(() -> simulator.test("/views/entry/export")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSONFile(jsonDir.resolve("views/entry/entry-export.json")));
+
+        // Serialize an object using @JSONResponse when no view is specified for an object that has only annotated fields
+        // The DEFAULT_VIEW_INCLUSION is the default value, but explicitly configured in case the default prime configuration changes
+        test.configureObjectMapper(om -> objectMapper.enable(MapperFeature.DEFAULT_VIEW_INCLUSION))
+                .simulate(() -> simulator.test("/views/entry/no-view-defined")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertJSONFile(jsonDir.resolve("views/entry/entry-no-view-defined.json")));
+
+        // Default view inclusion is enabled and if we serialize a @JSONResponse with a view that has no fields in the object - empty response
+        test.simulate(() -> simulator.test("/views/entry/wrong-view-defined")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSON("{}"));
+
+        // Ensure we get a response even when we disable the default view inclusion if we do not specify a view
+        test.configureObjectMapper(om -> objectMapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION))
+                .simulate(() -> simulator.test("/views/entry/no-view-defined")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertJSONFile(jsonDir.resolve("views/entry/entry-no-view-defined.json")));
+
+        // Default view inclusion is disabled and if we serialize a @JSONResponse with a view that has no fields in the object - empty response.
+        test.simulate(() -> simulator.test("/views/entry/wrong-view-defined")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSON("{}"));
+    }
+
+    @Test
+    public void get_action_backed_template_slashes() {
+        // Ok
+        simulator.test("/freemarker/action-backed")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Yo, nice template, I have an action.");
+
+        // Double slash, redirect to the correct location
+        simulator.test("/freemarker//action-backed")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Yo, nice template, I have an action.");
+
+        // Triple slashes, redirect to the correct location
+        simulator.test("/freemarker///action-backed")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Yo, nice template, I have an action.");
+
+        // Triple slashes, redirect to the correct location
+        try {
+            simulator.test("///bing.com")
+                    .get();
+            fail("Whoa!! We should have failed so hard it isn't even funny.");
+        } catch (Throwable e) {
+            assertEquals(e.getClass(), AssertionError.class);
+        }
+    }
+
+    @Test
+    public void get_action_package_collision() throws Exception {
+        test.simulate(() -> simulator.test("/foo/view/bar/baz")
+                        .withURLSegment("42")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertBodyContains("/foo/view/bar/baz!", "42"))
+
+                .simulate(() -> simulator.test("/foo/view/bar/baz")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo/view/bar/baz!", "empty"))
+
+                .simulate(() -> simulator.test("/foo/view/bar")
+                        .withURLSegment("42")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo/view/bar!", "42"))
+
+                .simulate(() -> simulator.test("/foo/view/bar")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo/view/bar!", "empty"))
+
+                .simulate(() -> simulator.test("/foo/view")
+                        .withURLSegment("42")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo/view!", "42"))
+
+                .simulate(() -> simulator.test("/foo/view")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo/view!", "empty"))
+
+                .simulate(() -> simulator.test("/foo")
+                        .withURLSegment("42")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo!", "42"))
+
+                .simulate(() -> simulator.test("/foo")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("/foo!", "empty"));
+    }
+
+    @Test
+    public void get_action_unknownParameters() throws Exception {
+        // simulate a development runtime
+        configuration.allowUnknownParameters = false;
+
+        // Even though the global config does not allow unknown parameters, this action does.
+        test.simulate(() -> simulator.test("/allow-unknown-parameters")
+                .withURLParameter("foo", "bar")
+                .get()
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void get_collectionConverter() throws Exception {
+        // Both of these will fail because the action has a List<String> as the backing values for this form, and the input field is a text field.
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withURLParameter("string", "foo,bar,baz")
+                .get()
+                .assertStatusCode(500));
+
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withURLParameter("string", "bar")
+                .withURLParameter("string", "baz")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(500));
+
+        // It will work if we use a backing collection with an iterator in the form to build multiple form fields
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withURLParameter("strings", "bar")
+                .withURLParameter("strings", "baz")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyDoesNotContain("__empty2__', '__empty3__")
+                .assertBodyContains("__empty1__")
+                .assertBodyContains("[bar, baz]")
+                .assertBodyContains("<input type=\"text\" id=\"string\" name=\"string\"/>")
+                .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"bar\"/")
+                .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"baz\"/"));
+
+        // Single string containing commas, output contains the same string
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withURLParameter("strings", "foo,bar,baz")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyDoesNotContain("__empty2__', '__empty3__")
+                .assertBodyContains("__empty1__")
+                .assertBodyContains("[foo,bar,baz]")
+                .assertBodyContains("<input type=\"text\" id=\"string\" name=\"string\"/>")
+                .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"foo,bar,baz\"/"));
+    }
+
+    @Test
+    public void get_default_results() {
+        // Take default of 'success' See DefaultForwardResultAction
+        simulator.test("/default-forward-result")
+                .get()
+                .assertStatusCode(200)
+                .assertBody("""
+                        Default Forward""");
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Unknown result code, still a 200 using ForwardImpl because this is the default in DefaultResultInvocationWorkflow
+        simulator.test("/default-forward-result")
+                .withURLParameter("resultCode", "foo")
+                .get()
+                .assertStatusCode(200)
+                .assertBody("""
+                        Default Forward""");
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Take default of 'success' See RequestedDefaultForwardResultAction
+        simulator.test("/requested-default-status-result")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyIsEmpty();
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Unknown result code, this should use the default mapping of '*' which results in a 201
+        simulator.test("/requested-default-status-result")
+                .withURLParameter("resultCode", "foo")
+                .get()
+                .assertStatusCode(201)
+                .assertBodyIsEmpty();
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Ensure the normal mapping works, expecting an .ftl per the forward result
+        simulator.test("/requested-default-forward-result")
+                .get()
+                .assertStatusCode(200)
+                .assertBody("""
+                        Hi!
+                        """);
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Unknown result code of 'foo', this should use the default mapping of '*' which results in a 201
+        simulator.test("/requested-default-forward-result")
+                .withURLParameter("resultCode", "foo")
+                .get()
+                .assertStatusCode(201)
+                .assertBody("""
+                        Hi!
+                        """);
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // No template, so expect an exception. Ensure the exception has the correct result code.
+        simulator.test("/requested-default-forward-result-no-template")
+                .withURLParameter("resultCode", "foo")
+                .get()
+                // 500 because the template is missing
+                .assertStatusCode(500);
+
+        // Ensure the exception contains the invalid result code of 'foo' and not '*' which is found in the default mapping.
+        TestUnhandledExceptionHandler.assertLastUnhandledException(new PrimeException(
+                "Missing result for action class [org.example.action.RequestedDefaultForwardResultNoTemplateAction] URI [/requested-default-forward-result-no-template] and result code [foo]"));
+    }
+
+    @Test
+    public void get_developmentExceptions() {
+        // Bad annotation @Action("{id}") it should be @Action("{uuid}")
+        simulator.test("/invalid-api/42")
+                .get()
+                .assertStatusCode(500);
+
+        // Bad parameter (i.e. /invalid-api?bad-param=42
+        simulator.test("/invalid-api")
+                .withURLParameter("bad-param", "42")
+                .get()
+                .assertStatusCode(500);
+    }
+
+    @Test
+    public void get_execute_redirect() throws Exception {
+        // Follow the redirect and another redirect and assert on that response as well - and ensure a message set in the first redirect gets all the way to the end
+        test.simulate(() -> simulator.test("/temp-redirect")
+                .get()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                // Messages are in the store
+                .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                .assertRedirect("/temp-redirect-target")
+
+                .executeRedirect(response -> response.assertStatusCode(302)
+                        // Message is still in the store
+                        .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                        .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                        .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                        .assertRedirect("/temp-redirect-target-target")
+
+                        .executeRedirect(subResponse -> subResponse.assertStatusCode(200)
+                                .assertBodyContains("Look Ma, I'm redirected.")
+                                // Message is still in the store and also rendered on the page
+                                .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                                .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                                .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                                .assertBodyContainsMessagesFromKey("[ERROR]", "[INFO]", "[WARNING]")
+                                .assertBodyContains("Error 3", "Info 3", "Warning 3")
+
+                                // Execute the form POST in the response body
+                                .executeFormPostInResponseBody("form", formResponse ->
+                                        formResponse.assertStatusCode(200)
+                                                .assertBodyContains(
+                                                        "textValue",
+                                                        "disabledEmpty", // This will be missing so the 'Empty' value will be rendered
+                                                        "hiddenValue",
+                                                        "noNameEmpty", // Missing because it has no name attribute
+                                                        "radioValue2",
+                                                        "checkboxValue2",
+                                                        "selectedValueOptionB",
+                                                        "textareaValue")
+                                                .assertBodyDoesNotContain(
+                                                        "disabledValue",
+                                                        "radioValue1",
+                                                        "checkboxValue1",
+                                                        "noNameValue",
+                                                        "selectEmpty")))));
+    }
+
+    @Test
+    public void get_execute_relativeRedirect() throws Exception {
+        // Follow the redirect and another redirect and assert on that response as well - and ensure a message set in the first redirect gets all the way to the end
+        test.simulate(() -> simulator.test("/temp-relative-redirect")
+                .get()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                // Messages are in the store
+                .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                .assertRedirect("temp-redirect-target")
+
+                .executeRedirect(response -> response.assertStatusCode(302)
+                        // Message is still in the store
+                        .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                        .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                        .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                        .assertRedirect("/temp-redirect-target-target")
+
+                        .executeRedirect(subResponse -> subResponse.assertStatusCode(200)
+                                .assertBodyContains("Look Ma, I'm redirected.")
+                                // Message is still in the store and also rendered on the page
+                                .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                                .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                                .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
+                                .assertBodyContainsMessagesFromKey("[ERROR]", "[INFO]", "[WARNING]")
+                                .assertBodyContains("Error 3", "Info 3", "Warning 3")
+
+                                // Execute the form POST in the response body
+                                .executeFormPostInResponseBody("form", formResponse ->
+                                        formResponse.assertStatusCode(200)
+                                                .assertBodyContains(
+                                                        "textValue",
+                                                        "disabledEmpty", // This will be missing so the 'Empty' value will be rendered
+                                                        "noNameEmpty", // Missing because it has no name attribute
+                                                        "hiddenValue",
+                                                        "radioValue",
+                                                        "checkboxValue",
+                                                        "textareaValue")
+                                                .assertBodyDoesNotContain(
+                                                        "disabledValue",
+                                                        "noNameValue")))));
+    }
+
+    @Test(enabled = false)
+    public void get_expressionEvaluatorSkippedUsesRequest() throws Exception {
+        // Tests that the expression evaluator safely gets skipped while looking for values and Prime then checks the
+        // HttpServletRequest and finds the value
+        test.simulate(() -> simulator.test("/value-in-request")
+                .get()
+                .assertBodyContains("baz"));
+
+        // TODO : Can't really assert on the request attributes. The request is made in a separate request/thread.
+        //        We could just delete this test, or come up with a way to keep a copy of the request around to assert on.
+        //        It looks like this test is supposed to be doing more than just checking request attributes. So
+        //        we should probably review this code and see if we are doing what this test originally was written
+        //        for.
+    }
+
+    @Test
+    public void get_freemarker_double_escape() {
+        simulator.test("/freemarker/double-escape")
+                .get()
+                .assertStatusCode(500);
+    }
+
+    @Test(dataProvider = "get_freemarker_escape_parameters")
+    public void get_freemarker_escape(String mode, boolean shouldBeEscaped) {
+        if (shouldBeEscaped) {
+            // Test from user data
+            simulator.test("/freemarker/escape")
+                    .withURLParameter("mode", mode)
+                    .get()
                     .assertStatusCode(200)
-                    .assertBody("""
-                                    We made it!
-                                    """)))
+                    .assertBodyContains("Output format: HTML",
+                            "Auto-escaping: true",
+                            "Select\u2026",
+                            ",\u0020",
+                            "&lt;p&gt;Are you sure?&lt;/p&gt;",
+                            "Hello, to access your account go to &lt;a href=&quot;https://foo.com&quot;&gt;foo.com&lt;/a&gt;.",
+                            "Dismiss",
+                            "Ignore")
+                    .assertBodyDoesNotContain("<p>Are you sure?</p>",
+                            "Hello, to access your account go to <a href=\"https://foo.com\">foo.com</a>.",
+                            "freemarker.core.TemplateHTMLOutputModel"); // Check to make sure that we don't toString an output model
+        } else {
+            simulator.test("/freemarker/escape")
+                    .withURLParameter("mode", mode)
+                    .get()
+                    .assertStatusCode(200)
+                    .assertBodyContains("Output format: HTML",
+                            "Auto-escaping: true",
+                            "Select\u2026",
+                            ",\u0020",
+                            "<p>Are you sure?</p>",
+                            "Hello, to access your account go to <a href=\"https://foo.com\">foo.com</a>.",
+                            "Dismiss",
+                            "Ignore")
+                    .assertBodyDoesNotContain("&lt;p&gt;Are you sure?&lt;/p&gt;",
+                            "Hello, to access your account go to &lt;a href=&quot;https://foo.com&quot;&gt;foo.com&lt;/a&gt;.",
+                            "freemarker.core.TemplateHTMLOutputModel"); // Check to make sure that we don't toString an output model
+        }
+    }
+
+    @DataProvider
+    public Object[][] get_freemarker_escape_parameters() {
+        return new Object[][]{
+                {"message", false}, // We explicitly set the control to not escape anything
+                {"function", true}, // This is a direct function call
+                {"functionUnescaped", false}, // Direct function call wrapped in noautoesc
+                {"directProperties", true}, // This is a direct property access
+                {"indirectProperties", true} // This is an indirect property access using ?eval
+        };
+    }
+
+    @Test
+    public void get_fullFormWithAllAttributes() throws Exception {
+        simulator.test("/user/full-form")
+                .get()
+                .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
+    }
+
+    @Test
+    public void get_fuzzing_invalid_expression() throws Exception {
+        // simulate a production runtime
+        configuration.allowUnknownParameters = true;
+        test.simulate(() -> simulator.test("/vanilla")
+                // This is an invalid expression, but unknown parameters are ignored.
+                .withURLParameter("class.method", "foo")
+                .get()
+                .assertStatusCode(200));
+
+        // No un-handled exception
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // simulate dev runtime
+        configuration.allowUnknownParameters = false;
+        test.simulate(() -> simulator.test("/vanilla")
+                // This is an invalid expression, an exception will be thrown and return a 500.
+                .withURLParameter("class.method", "foo")
+                .get()
+                .assertStatusCode(500));
+
+        // Expect to have thrown InvalidExpressionException
+        TestUnhandledExceptionHandler.assertLastUnhandledException(new InvalidExpressionException("The expression string [class.method] is invalid."));
+    }
+
+    @Test
+    public void get_fuzzing_invalid_expression_2() throws Exception {
+        // Allow unknown parameters
+        configuration.allowUnknownParameters = true;
+        test.simulate(() -> simulator.test("/user/edit")
+                .withURLParameter("user", "org.example.domain.User")
+                .get()
+                .assertStatusCode(200));
+
+        // No un-handled exception
+        TestUnhandledExceptionHandler.assertNoUnhandledException();
+
+        // Back to dev runtime - do not allow unknown parameters. The action behavior will not change, but there will be an unhandled exception logged.
+        configuration.allowUnknownParameters = false;
+        test.simulate(() -> simulator.test("/user/edit")
+                .withURLParameter("user", "org.example.domain.User")
+                .get()
+                .assertStatusCode(200));
+
+        // Expect to have thrown ConverterStateException
+        TestUnhandledExceptionHandler.assertLastUnhandledException(new ConverterStateException("While evaluating the expression [user] in class [org.example.action.user.EditAction]. No type converter found for the type [org.example.domain.User]."));
+    }
+
+    @Test
+    public void get_index() throws Exception {
+        test.simulate(() -> simulator.test("/user/")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Yeah!"));
+        test.simulate(() -> simulator.test("/user")
+                .get()
+                .assertStatusCode(301)
+                .assertRedirect("/user/"));
+    }
+
+    @Test
+    public void get_jwtAuthorized() throws Exception {
+        JwtAuthorizedAction.authorized = true;
+
+        // Test with JWT scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200));
+
+        // Test with JWT scheme, mixed case
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "jWt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200));
+
+        // Test with Bearer scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertStatusCode(200));
+
+        // Test with Bearer scheme, mixed case
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "bEaReR eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertStatusCode(200));
+
+        // Missing JWT w/ Bearer scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "Bearer ")
+                .get()
+                .assertStatusCode(401));
+
+
+        // Missing JWT w/ Bearer scheme, no space after scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "Bearer")
+                .get()
+                .assertStatusCode(401));
+
+        // Bad JWT w/ Bearer scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "Bearer Foo")
+                .get()
+                .assertStatusCode(401));
+
+        // Missing JWT w/ JWT scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT ")
+                .get()
+                .assertStatusCode(401));
+
+
+        // Missing JWT w/ JWT scheme, no space after scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT")
+                .get()
+                .assertStatusCode(401));
+
+        // Bad JWT w/ JWT scheme
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT Foo")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtDisabledJwtAuthentication() throws Exception {
+        // Send in a JWT Authorization header when the Action has JWT disabled. Should always get a 401. When a JWT is provided, the action expects JWT to be enabled.
+        test.simulate(() -> simulator.test("/jwt-authorized-disabled")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertStatusCode(401));
+
+        // Same, use Bearer scheme
+        test.simulate(() -> simulator.test("/jwt-authorized-disabled")
+                .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtExpired() throws Exception {
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withURLParameter("authorized", true)
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NDUxMDA3MzF9.K18gIegEBfxgj8rU4D2WDh3CzEmRUmy8qBS7SWAcG9w")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtInvalidSignature() throws Exception {
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withURLParameter("authorized", true)
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.aaabbbcccddd")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtMissingAuthorizeHeader() throws Exception {
+        JwtAuthorizedAction.authorized = true;
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtNotAuthorized() throws Exception {
+        JwtAuthorizedAction.authorized = false;
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwtNotBefore() throws Exception {
+        // Validating the JWT registered claim 'nbf' (Not Before). The JWT is validly signed, but it is instructed not to be valid before some point in the future. Expecting a 401.
+        JwtAuthorizedAction.authorized = true;
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjQ2MzIzOTY2NjV9.mRvvyJXvDD8RQ_PM1TadZdZNYXRa9CjOx62Tk866538")
+                .get()
+                .assertStatusCode(401));
+    }
+
+    @Test
+    public void get_jwt_jwtEnabled_deprecated() throws Exception {
+        // Test an action using the deprecated jwtEnabled instead of the jwt scheme
+        test.simulate(() -> simulator.test("/jwt-authorized-deprecated")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void get_jwt_other_scheme() throws Exception {
+        // Test an action with a jwt based scheme, but not named 'jwt'
+        test.simulate(() -> simulator.test("/jwt-authorized-other")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void get_largeFTL() {
+        simulator.test("/large-ftl")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("large FTL");
+    }
+
+    @Test
+    public void get_fieldMessage() throws Exception {
+        test.simulate(() -> simulator.test("/field-message")
+                .get()
+                .assertStatusCode(200)
+                .assertFieldHasNoErrors("foo")
+                .assertFieldHasNoErrors("bar")
+                .custom(r -> assertThrows(AssertionError.class, () -> r.assertFieldHasNoErrors("baz")))
+                .assertFieldHasErrorMessage("baz", "baz has an error")
+                .assertFieldHasErrorMessageFromKey("baz", "[ERROR]", "baz")
+                .assertFieldHasErrorCode("baz", "[ERROR]baz"));
+    }
+
+    @Test
+    public void get_message_callback() throws Exception {
+        // call an action that adds messages that calls another action that adds messages to ensure we can assert on the message store properly.
+        test.simulate(() -> simulator.test("/callback")
+                .get()
+                .assertStatusCode(200)
+                .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
+                .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
+                .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]"));
+    }
+
+    @Test
+    public void get_metrics() throws Exception {
+        simulator.test("/user/full-form")
+                .get()
+                .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
+
+        Map<String, Timer> timers = metricRegistry.getTimers();
+        assertEquals(timers.get("prime-mvc.[/user/full-form].requests").getCount(), 1);
+        assertEquals(timers.get("prime-mvc.[*].requests").getCount(), 1);
+    }
+
+    @Test
+    public void get_metricsErrors() {
+        simulator.test("/execute-method-throws-exception")
+                .get()
+                .assertStatusCode(500);
+
+        Map<String, Timer> timers = metricRegistry.getTimers();
+        assertEquals(timers.get("prime-mvc.[/execute-method-throws-exception].requests").getCount(), 1);
+
+        Map<String, Meter> meters = metricRegistry.getMeters();
+        assertEquals(meters.get("prime-mvc.[/execute-method-throws-exception].errors").getCount(), 1);
+        assertEquals(meters.get("prime-mvc.[*].errors").getCount(), 1);
+    }
+
+    @Test
+    public void get_modifyRequest() throws Exception {
+        // The Test HTTP request consumer will have added an HTTP request header.
+        simulator.test("/foo")
+                .get()
+                .assertStatusCode(200)
+                .custom(result -> assertEquals(result.request.getHeader("X-Test-HTTP-Request-Consumer"), "true"));
+    }
+
+    @Test
+    public void get_nested_parameters() throws Exception {
+        test.simulate(() -> simulator.test("/nested")
+                .withURLSegment("42")
+                .withURLSegment("99")
+                .withURLSegment("parameter")
+                .withURLSegment("foo")
+                .withURLSegment("bar")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200)
+                .assertBodyContains("Success!", "preParam1=42", "preParam2=99", "endParam1=foo", "endParam2=bar"));
+    }
+
+    @Test
+    public void get_nonFormFields() throws Exception {
+        simulator.test("/user/details-fields")
+                .get()
+                .assertBodyFile(Path.of("src/test/resources/html/details-fields.html"));
+    }
+
+    @Test
+    public void get_objectMapValues() throws Exception {
+        // Testing ?eval against a generic map
+        test.simulate(() -> simulator.test("/object-map-values")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains(
+                        "Name:foo.data.preferences.coffee.style",
+                        ":Value::Value:"));
+    }
+
+    @Test
+    public void get_onlyKnownParameters() throws Exception {
+        // Action w/out @UnknownParameters
+        configuration.allowUnknownParameters = false;
+        test.simulate(() -> simulator.test("/only-known-parameters")
+                .withParameter("foo", "bar")
+                .withParameter("foo", "baz")
+                .withParameter("foo.bar", "baz")
+                .withParameter("foo/0/bar/bam", "purple")
+                .post()
+                .assertStatusCode(500)
+                .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test
+    public void get_overrideClassNameForURI() throws Exception {
+        test.simulate(() -> simulator.test("/OverrideMe")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyIsEmpty());
+
+        assertTrue(OverrideMeAction.invoked);
+
+        // Reset
+        OverrideMeAction.invoked = false;
+
+        boolean succeeded = false;
+
+        try {
+            test.simulate(() -> simulator.test("/override-me")
+                    .get()
+                    .assertStatusCode(404)
+                    .assertBodyIsEmpty());
+            succeeded = true;
+        } catch (Error expected) {
+        }
+
+        if (succeeded) {
+            fail("Expected a failure!");
+        }
+    }
+
+    @Test
+    public void get_percent_encoded_segment() throws Exception {
+        test.simulate(() -> simulator.test("/foo/view")
+                .withURLSegment("<strong>foo</strong>")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("/foo/view!", "id=&lt;strong&gt;foo&lt;/strong&gt;"));
+
+        test.simulate(() -> simulator.test("/foo/view/%3Cstrong%3Efoo%3C%2Fstrong%3E")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("/foo/view!", "id=&lt;strong&gt;foo&lt;/strong&gt;"));
+    }
+
+    @Test
+    public void get_postParameterBeforeFormPrepare() throws Exception {
+        // Ensure we hit PostParameterMethods in an action when we build a new action based upon hitting a
+        // form tag that has a different action then the current action invocation.
+
+        test.simulate(() -> simulator.test("/scope/page-two")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertBodyContains("postParameterMethodCalled:first")
+                        .assertBodyContains("formPrepareMethodCalled:second"))
+
+                // Now hit /api/page-one which contains a form tag with an action of /scope/page-two
+                .simulate(() -> simulator.test("/scope/page-one")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains("postParameterMethodCalled:first")
+                        .assertBodyContains("formPrepareMethodCalled:second"));
+    }
+
+    @Test
+    public void get_preRender() {
+        simulator.test("/pre-render-method")
+                .withURLParameter("result", "forward")
+                .get()
+                .assertStatusCode(200)
+                .assertContentType("text/html; charset=UTF-8")
+                .assertBodyContains("Forward_Yep!", "JSON_Nope!", "Noop_Nope!");
+
+        simulator.test("/pre-render-method")
+                .withURLParameter("result", "json")
+                .get()
+                .assertStatusCode(200)
+                .assertContentType("application/json; charset=UTF-8")
+                .assertBodyContains("trust me it is json");
+
+        simulator.test("/pre-render-method")
+                .withURLParameter("result", "noop")
+                .get()
+                .assertStatusCode(201)
+                .assertContentType("application/potato")
+                .assertBodyContains("You've been no-oped!");
+    }
+
+    @Test
+    public void get_redirect() throws Exception {
+        // Contains no parameters
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo")
+                .get()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/foo"));
+
+        // Contains a single parameter, calling beginQuery is optional
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo?bar=baz")
+                .assertRedirect("/foo", params -> params.with("bar", "baz")));
+
+        // Contains a single parameter with calling beginQuery()
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo?bar=baz")
+                .assertRedirect("/foo", params -> params.beginQuery()
+                        .with("bar", "baz")));
+
+        // Contains multiple parameters
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz&boom=dynamite")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo?bar=baz&boom=dynamite")
+                .assertRedirect("/foo", params -> params.beginQuery()
+                        .with("bar", "baz")
+                        .with("boom", "dynamite")));
+
+        // Contains a single parameter after a fragment
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo#bar=baz")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo#bar=baz")
+                .assertRedirect("/foo", params -> params.beginFragment()
+                        .with("bar", "baz")));
+
+        // Contains multiple parameters after a fragment
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo#bar=baz&boom=dynamite")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo#bar=baz&boom=dynamite")
+                .assertRedirect("/foo", params -> params.beginFragment()
+                        .with("bar", "baz")
+                        .with("boom", "dynamite")));
+
+        // Contains a single parameter and a single parameter after a fragment
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz#middle=out")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo?bar=baz#middle=out")
+                .assertRedirect("/foo", params -> params.beginQuery()
+                        .with("bar", "baz")
+                        .beginFragment()
+                        .with("middle", "out")));
+
+        // Contains multiple parameters and multiple parameters after a fragment
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz&boom=dynamite#middle=out&not=hotdog")
+                .get()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/foo?bar=baz&boom=dynamite#middle=out&not=hotdog")
+                .assertRedirect("/foo", params -> params.beginQuery()
+                        .with("bar", "baz")
+                        .with("boom", "dynamite")
+                        .beginFragment()
+                        .with("middle", "out")
+                        .with("not", "hotdog")));
+
+        // URL has multiple parameters
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bar=baz&q=foo&code=bar")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/foo?bar=baz&q=foo&code=bar")
+                .assertRedirect("/foo", params -> params.beginQuery()
+                        .with("bar", "baz")
+                        .with("q", "foo")
+                        .with("code", "bar")));
+
+        // When we expect parameters, assert that the URL does not have parameters. This tests for an edge case
+        // that we have fixed in the RequestResult.
+        try {
+            test.simulate(() -> simulator.test("/complex-redirect")
+                    .withURLParameter("redirectURI", "/foo?bar=baz&q=foo&code=bar")
+                    .get()
+                    .assertStatusCode(302)
+                    .assertRedirect("/foo"));
+            fail("Expected a failure.");
+        } catch (Error e) {
+            assertEquals(e.getClass(), AssertionError.class);
+        }
+    }
+
+    @Test
+    public void get_redirect_flash_scope_messageLookup() throws Exception {
+        // Use case, see if we can correctly assert on a message key in a body when the message only exists in a bundle for the initial action
+        simulator.test("/flash-scope/redirect")
+                .get()
+                .assertStatusCode(302)
+                .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
+                .assertRedirect("/flash-scope/")
+                .executeRedirectReturnResult(result -> result.assertStatusCode(200)
+                        .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
+                        .assertBodyContainsMessagesFromKey("[FlashScopeMessageKey]")
+                        .assertBody("""
+                                This is an index page.
+                                
+                                  Info:This is a message!
+                                
+                                """)
+                );
+    }
+
+    @Test
+    public void get_redirect_withActual() throws Exception {
+        // Contains no parameters
+        test.simulate(() -> simulator.test("/complex-redirect")
+                .withURLParameter("redirectURI", "/foo?bing=bam&instant=" + System.currentTimeMillis())
+                .get()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/foo", params -> params.withActual("instant")
+                        .with("bing", "bam")));
+    }
+
+    @Test
+    public void get_redirects_nested() throws Exception {
+        // See if we can nest many redirects
+        test.simulate(() -> simulator
+                .test("/router/redirect")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/router/redirect/1")
+                .followRedirect(r1 -> r1
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/2")
+                        .followRedirect(r2 -> r2
+                                .assertStatusCode(302)
+                                .assertRedirect("/router/redirect/3")
+                                .followRedirect(r3 -> r3
+                                        .assertStatusCode(302)
+                                        .assertRedirect("/router/redirect/4")
+                                        .followRedirect(r4 -> r4
+                                                .assertStatusCode(302)
+                                                .assertRedirect("/router/redirect/5")
+                                                .followRedirect(r5 -> r5
+                                                        .assertStatusCode(200)
+                                                        .assertBodyIsEmpty()))))));
+
+        // See if we can be more civilized and come back out to the top level as well
+        test.simulate(() -> simulator
+                .test("/router/redirect")
+                .get()
+                .assertStatusCode(302)
+                .assertRedirect("/router/redirect/1")
+                .followRedirect(r1 -> r1
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/2"))
+                .followRedirect(r2 -> r2
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/3"))
+                .followRedirect(r3 -> r3
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/4"))
+                .followRedirect(r4 -> r4
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/5"))
+                .followRedirect(r5 -> r5
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty())
         );
-  }
 
-  @Test
-  public void get() throws Exception {
-    // Not called yet
-    assertEquals(MockMVCWorkflowFinalizer.Called.get(), 0);
-
-    simulator.test("/user/edit")
-             .get()
-             .assertStatusCode(200)
-             // header name is not case-sensitive
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertHeaderContains("cache-control", "no-cache")
-             .assertHeaderDoesNotContain("Potato")
-             .assertBodyFile(Path.of("src/test/resources/html/edit.html"));
-
-    // 1 call! Ah ah ah...
-    assertEquals(MockMVCWorkflowFinalizer.Called.get(), 1);
-
-    EditAction.getCalled = false;
-    simulator.test("/user/edit")
-             .withHeader(Headers.MethodOverride, Methods.GET)
-             .get()
-             .assertStatusCode(200);
-
-    assertTrue(EditAction.getCalled);
-
-    // 2 calls! Ah ah ah...
-    assertEquals(MockMVCWorkflowFinalizer.Called.get(), 2);
-  }
-
-  @Test
-  public void get_ContentTypeOverride() {
-    simulator.test("/content-type-override")
-             .get()
-             .assertStatusCode(200)
-             .assertContentType("application/json+scim");
-
-    // Override from the JSON annotation
-    simulator.test("/content-type-override")
-             .withURLParameter("status", 400)
-             .get()
-             .assertStatusCode(400)
-             .assertContentType("application/json+error");
-  }
-
-  @Test
-  public void get_JSONView() throws Exception {
-    test.simulate(() -> simulator.test("/views/entry/api")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSONFile(jsonDir.resolve("views/entry/entry-api.json")));
-
-    test.simulate(() -> simulator.test("/views/entry/export")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSONFile(jsonDir.resolve("views/entry/entry-export.json")));
-
-    // Serialize an object using @JSONResponse when no view is specified for an object that has only annotated fields
-    // The DEFAULT_VIEW_INCLUSION is the default value, but explicitly configured in case the default prime configuration changes
-    test.configureObjectMapper(om -> objectMapper.enable(MapperFeature.DEFAULT_VIEW_INCLUSION))
-        .simulate(() -> simulator.test("/views/entry/no-view-defined")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSONFile(jsonDir.resolve("views/entry/entry-no-view-defined.json")));
-
-    // Default view inclusion is enabled and if we serialize a @JSONResponse with a view that has no fields in the object - empty response
-    test.simulate(() -> simulator.test("/views/entry/wrong-view-defined")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSON("{}"));
-
-    // Ensure we get a response even when we disable the default view inclusion if we do not specify a view
-    test.configureObjectMapper(om -> objectMapper.disable(MapperFeature.DEFAULT_VIEW_INCLUSION))
-        .simulate(() -> simulator.test("/views/entry/no-view-defined")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSONFile(jsonDir.resolve("views/entry/entry-no-view-defined.json")));
-
-    // Default view inclusion is disabled and if we serialize a @JSONResponse with a view that has no fields in the object - empty response.
-    test.simulate(() -> simulator.test("/views/entry/wrong-view-defined")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSON("{}"));
-  }
-
-  @Test
-  public void get_action_backed_template_slashes() {
-    // Ok
-    simulator.test("/freemarker/action-backed")
-             .get()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Yo, nice template, I have an action.");
-
-    // Double slash, redirect to the correct location
-    simulator.test("/freemarker//action-backed")
-             .get()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Yo, nice template, I have an action.");
-
-    // Triple slashes, redirect to the correct location
-    simulator.test("/freemarker///action-backed")
-             .get()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Yo, nice template, I have an action.");
-
-    // Triple slashes, redirect to the correct location
-    try {
-      simulator.test("///bing.com")
-               .get();
-      fail("Whoa!! We should have failed so hard it isn't even funny.");
-    } catch (Throwable e) {
-      assertEquals(e.getClass(), AssertionError.class);
-    }
-  }
-
-  @Test
-  public void get_action_package_collision() throws Exception {
-    test.simulate(() -> simulator.test("/foo/view/bar/baz")
-                                 .withURLSegment("42")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains("/foo/view/bar/baz!", "42"))
-
-        .simulate(() -> simulator.test("/foo/view/bar/baz")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view/bar/baz!", "empty"))
-
-        .simulate(() -> simulator.test("/foo/view/bar")
-                                 .withURLSegment("42")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view/bar!", "42"))
-
-        .simulate(() -> simulator.test("/foo/view/bar")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view/bar!", "empty"))
-
-        .simulate(() -> simulator.test("/foo/view")
-                                 .withURLSegment("42")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view!", "42"))
-
-        .simulate(() -> simulator.test("/foo/view")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view!", "empty"))
-
-        .simulate(() -> simulator.test("/foo")
-                                 .withURLSegment("42")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo!", "42"))
-
-        .simulate(() -> simulator.test("/foo")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo!", "empty"));
-  }
-
-  @Test
-  public void get_action_unknownParameters() throws Exception {
-    // simulate a development runtime
-    configuration.allowUnknownParameters = false;
-
-    // Even though the global config does not allow unknown parameters, this action does.
-    test.simulate(() -> simulator.test("/allow-unknown-parameters")
-                                 .withURLParameter("foo", "bar")
-                                 .get()
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void get_collectionConverter() throws Exception {
-    // Both of these will fail because the action has a List<String> as the backing values for this form, and the input field is a text field.
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withURLParameter("string", "foo,bar,baz")
-                                 .get()
-                                 .assertStatusCode(500));
-
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withURLParameter("string", "bar")
-                                 .withURLParameter("string", "baz")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(500));
-
-    // It will work if we use a backing collection with an iterator in the form to build multiple form fields
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withURLParameter("strings", "bar")
-                                 .withURLParameter("strings", "baz")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyDoesNotContain("__empty2__', '__empty3__")
-                                 .assertBodyContains("__empty1__")
-                                 .assertBodyContains("[bar, baz]")
-                                 .assertBodyContains("<input type=\"text\" id=\"string\" name=\"string\"/>")
-                                 .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"bar\"/")
-                                 .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"baz\"/"));
-
-    // Single string containing commas, output contains the same string
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withURLParameter("strings", "foo,bar,baz")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyDoesNotContain("__empty2__', '__empty3__")
-                                 .assertBodyContains("__empty1__")
-                                 .assertBodyContains("[foo,bar,baz]")
-                                 .assertBodyContains("<input type=\"text\" id=\"string\" name=\"string\"/>")
-                                 .assertBodyContains("<input type=\"text\" id=\"strings\" name=\"strings\" value=\"foo,bar,baz\"/"));
-  }
-
-  @Test
-  public void get_default_results() {
-    // Take default of 'success' See DefaultForwardResultAction
-    simulator.test("/default-forward-result")
-             .get()
-             .assertStatusCode(200)
-             .assertBody("""
-                             Default Forward""");
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Unknown result code, still a 200 using ForwardImpl because this is the default in DefaultResultInvocationWorkflow
-    simulator.test("/default-forward-result")
-             .withURLParameter("resultCode", "foo")
-             .get()
-             .assertStatusCode(200)
-             .assertBody("""
-                             Default Forward""");
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Take default of 'success' See RequestedDefaultForwardResultAction
-    simulator.test("/requested-default-status-result")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyIsEmpty();
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Unknown result code, this should use the default mapping of '*' which results in a 201
-    simulator.test("/requested-default-status-result")
-             .withURLParameter("resultCode", "foo")
-             .get()
-             .assertStatusCode(201)
-             .assertBodyIsEmpty();
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Ensure the normal mapping works, expecting an .ftl per the forward result
-    simulator.test("/requested-default-forward-result")
-             .get()
-             .assertStatusCode(200)
-             .assertBody("""
-                             Hi!
-                             """);
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Unknown result code of 'foo', this should use the default mapping of '*' which results in a 201
-    simulator.test("/requested-default-forward-result")
-             .withURLParameter("resultCode", "foo")
-             .get()
-             .assertStatusCode(201)
-             .assertBody("""
-                             Hi!
-                             """);
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // No template, so expect an exception. Ensure the exception has the correct result code.
-    simulator.test("/requested-default-forward-result-no-template")
-             .withURLParameter("resultCode", "foo")
-             .get()
-             // 500 because the template is missing
-             .assertStatusCode(500);
-
-    // Ensure the exception contains the invalid result code of 'foo' and not '*' which is found in the default mapping.
-    TestUnhandledExceptionHandler.assertLastUnhandledException(new PrimeException(
-        "Missing result for action class [org.example.action.RequestedDefaultForwardResultNoTemplateAction] URI [/requested-default-forward-result-no-template] and result code [foo]"));
-  }
-
-  @Test
-  public void get_developmentExceptions() {
-    // Bad annotation @Action("{id}") it should be @Action("{uuid}")
-    simulator.test("/invalid-api/42")
-             .get()
-             .assertStatusCode(500);
-
-    // Bad parameter (i.e. /invalid-api?bad-param=42
-    simulator.test("/invalid-api")
-             .withURLParameter("bad-param", "42")
-             .get()
-             .assertStatusCode(500);
-  }
-
-  @Test
-  public void get_execute_redirect() throws Exception {
-    // Follow the redirect and another redirect and assert on that response as well - and ensure a message set in the first redirect gets all the way to the end
-    test.simulate(() -> simulator.test("/temp-redirect")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 // Messages are in the store
-                                 .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                 .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                 .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                 .assertRedirect("/temp-redirect-target")
-
-                                 .executeRedirect(response -> response.assertStatusCode(302)
-                                                                      // Message is still in the store
-                                                                      .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                                                      .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                                                      .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                                                      .assertRedirect("/temp-redirect-target-target")
-
-                                                                      .executeRedirect(subResponse -> subResponse.assertStatusCode(200)
-                                                                                                                 .assertBodyContains("Look Ma, I'm redirected.")
-                                                                                                                 // Message is still in the store and also rendered on the page
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                                                                                                 .assertBodyContainsMessagesFromKey("[ERROR]", "[INFO]", "[WARNING]")
-                                                                                                                 .assertBodyContains("Error 3", "Info 3", "Warning 3")
-
-                                                                                                                 // Execute the form POST in the response body
-                                                                                                                 .executeFormPostInResponseBody("form", formResponse ->
-                                                                                                                     formResponse.assertStatusCode(200)
-                                                                                                                                 .assertBodyContains(
-                                                                                                                                     "textValue",
-                                                                                                                                     "disabledEmpty", // This will be missing so the 'Empty' value will be rendered
-                                                                                                                                     "hiddenValue",
-                                                                                                                                     "noNameEmpty", // Missing because it has no name attribute
-                                                                                                                                     "radioValue2",
-                                                                                                                                     "checkboxValue2",
-                                                                                                                                     "selectedValueOptionB",
-                                                                                                                                     "textareaValue")
-                                                                                                                                 .assertBodyDoesNotContain(
-                                                                                                                                     "disabledValue",
-                                                                                                                                     "radioValue1",
-                                                                                                                                     "checkboxValue1",
-                                                                                                                                     "noNameValue",
-                                                                                                                                     "selectEmpty")))));
-  }
-
-  @Test
-  public void get_execute_relativeRedirect() throws Exception {
-    // Follow the redirect and another redirect and assert on that response as well - and ensure a message set in the first redirect gets all the way to the end
-    test.simulate(() -> simulator.test("/temp-relative-redirect")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 // Messages are in the store
-                                 .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                 .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                 .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                 .assertRedirect("temp-redirect-target")
-
-                                 .executeRedirect(response -> response.assertStatusCode(302)
-                                                                      // Message is still in the store
-                                                                      .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                                                      .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                                                      .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                                                      .assertRedirect("/temp-redirect-target-target")
-
-                                                                      .executeRedirect(subResponse -> subResponse.assertStatusCode(200)
-                                                                                                                 .assertBodyContains("Look Ma, I'm redirected.")
-                                                                                                                 // Message is still in the store and also rendered on the page
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                                                                                                 .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]")
-                                                                                                                 .assertBodyContainsMessagesFromKey("[ERROR]", "[INFO]", "[WARNING]")
-                                                                                                                 .assertBodyContains("Error 3", "Info 3", "Warning 3")
-
-                                                                                                                 // Execute the form POST in the response body
-                                                                                                                 .executeFormPostInResponseBody("form", formResponse ->
-                                                                                                                     formResponse.assertStatusCode(200)
-                                                                                                                                 .assertBodyContains(
-                                                                                                                                     "textValue",
-                                                                                                                                     "disabledEmpty", // This will be missing so the 'Empty' value will be rendered
-                                                                                                                                     "noNameEmpty", // Missing because it has no name attribute
-                                                                                                                                     "hiddenValue",
-                                                                                                                                     "radioValue",
-                                                                                                                                     "checkboxValue",
-                                                                                                                                     "textareaValue")
-                                                                                                                                 .assertBodyDoesNotContain(
-                                                                                                                                     "disabledValue",
-                                                                                                                                     "noNameValue")))));
-  }
-
-  @Test(enabled = false)
-  public void get_expressionEvaluatorSkippedUsesRequest() throws Exception {
-    // Tests that the expression evaluator safely gets skipped while looking for values and Prime then checks the
-    // HttpServletRequest and finds the value
-    test.simulate(() -> simulator.test("/value-in-request")
-                                 .get()
-                                 .assertBodyContains("baz"));
-
-    // TODO : Can't really assert on the request attributes. The request is made in a separate request/thread.
-    //        We could just delete this test, or come up with a way to keep a copy of the request around to assert on.
-    //        It looks like this test is supposed to be doing more than just checking request attributes. So
-    //        we should probably review this code and see if we are doing what this test originally was written
-    //        for.
-  }
-
-  @Test
-  public void get_freemarker_double_escape() {
-    simulator.test("/freemarker/double-escape")
-             .get()
-             .assertStatusCode(500);
-  }
-
-  @Test(dataProvider = "get_freemarker_escape_parameters")
-  public void get_freemarker_escape(String mode, boolean shouldBeEscaped) {
-    if (shouldBeEscaped) {
-      // Test from user data
-      simulator.test("/freemarker/escape")
-               .withURLParameter("mode", mode)
-               .get()
-               .assertStatusCode(200)
-               .assertBodyContains("Output format: HTML",
-                                   "Auto-escaping: true",
-                                   "Select\u2026",
-                                   ",\u0020",
-                                   "&lt;p&gt;Are you sure?&lt;/p&gt;",
-                                   "Hello, to access your account go to &lt;a href=&quot;https://foo.com&quot;&gt;foo.com&lt;/a&gt;.",
-                                   "Dismiss",
-                                   "Ignore")
-               .assertBodyDoesNotContain("<p>Are you sure?</p>",
-                                         "Hello, to access your account go to <a href=\"https://foo.com\">foo.com</a>.",
-                                         "freemarker.core.TemplateHTMLOutputModel"); // Check to make sure that we don't toString an output model
-    } else {
-      simulator.test("/freemarker/escape")
-               .withURLParameter("mode", mode)
-               .get()
-               .assertStatusCode(200)
-               .assertBodyContains("Output format: HTML",
-                                   "Auto-escaping: true",
-                                   "Select\u2026",
-                                   ",\u0020",
-                                   "<p>Are you sure?</p>",
-                                   "Hello, to access your account go to <a href=\"https://foo.com\">foo.com</a>.",
-                                   "Dismiss",
-                                   "Ignore")
-               .assertBodyDoesNotContain("&lt;p&gt;Are you sure?&lt;/p&gt;",
-                                         "Hello, to access your account go to &lt;a href=&quot;https://foo.com&quot;&gt;foo.com&lt;/a&gt;.",
-                                         "freemarker.core.TemplateHTMLOutputModel"); // Check to make sure that we don't toString an output model
-    }
-  }
-
-  @DataProvider
-  public Object[][] get_freemarker_escape_parameters() {
-    return new Object[][]{
-        {"message", false}, // We explicitly set the control to not escape anything
-        {"function", true}, // This is a direct function call
-        {"functionUnescaped", false}, // Direct function call wrapped in noautoesc
-        {"directProperties", true}, // This is a direct property access
-        {"indirectProperties", true} // This is an indirect property access using ?eval
-    };
-  }
-
-  @Test
-  public void get_fullFormWithAllAttributes() throws Exception {
-    simulator.test("/user/full-form")
-             .get()
-             .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
-  }
-
-  @Test
-  public void get_fuzzing_invalid_expression() throws Exception {
-    // simulate a production runtime
-    configuration.allowUnknownParameters = true;
-    test.simulate(() -> simulator.test("/vanilla")
-                                 // This is an invalid expression, but unknown parameters are ignored.
-                                 .withURLParameter("class.method", "foo")
-                                 .get()
-                                 .assertStatusCode(200));
-
-    // No un-handled exception
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // simulate dev runtime
-    configuration.allowUnknownParameters = false;
-    test.simulate(() -> simulator.test("/vanilla")
-                                 // This is an invalid expression, an exception will be thrown and return a 500.
-                                 .withURLParameter("class.method", "foo")
-                                 .get()
-                                 .assertStatusCode(500));
-
-    // Expect to have thrown InvalidExpressionException
-    TestUnhandledExceptionHandler.assertLastUnhandledException(new InvalidExpressionException("The expression string [class.method] is invalid."));
-  }
-
-  @Test
-  public void get_fuzzing_invalid_expression_2() throws Exception {
-    // Allow unknown parameters
-    configuration.allowUnknownParameters = true;
-    test.simulate(() -> simulator.test("/user/edit")
-                                 .withURLParameter("user", "org.example.domain.User")
-                                 .get()
-                                 .assertStatusCode(200));
-
-    // No un-handled exception
-    TestUnhandledExceptionHandler.assertNoUnhandledException();
-
-    // Back to dev runtime - do not allow unknown parameters. The action behavior will not change, but there will be an unhandled exception logged.
-    configuration.allowUnknownParameters = false;
-    test.simulate(() -> simulator.test("/user/edit")
-                                 .withURLParameter("user", "org.example.domain.User")
-                                 .get()
-                                 .assertStatusCode(200));
-
-    // Expect to have thrown ConverterStateException
-    TestUnhandledExceptionHandler.assertLastUnhandledException(new ConverterStateException("While evaluating the expression [user] in class [org.example.action.user.EditAction]. No type converter found for the type [org.example.domain.User]."));
-  }
-
-  @Test
-  public void get_index() throws Exception {
-    test.simulate(() -> simulator.test("/user/")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains("Yeah!"));
-    test.simulate(() -> simulator.test("/user")
-                                 .get()
-                                 .assertStatusCode(301)
-                                 .assertRedirect("/user/"));
-  }
-
-  @Test
-  public void get_jwtAuthorized() throws Exception {
-    JwtAuthorizedAction.authorized = true;
-
-    // Test with JWT scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200));
-
-    // Test with JWT scheme, mixed case
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "jWt eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200));
-
-    // Test with Bearer scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertStatusCode(200));
-
-    // Test with Bearer scheme, mixed case
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "bEaReR eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertStatusCode(200));
-
-    // Missing JWT w/ Bearer scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "Bearer ")
-                                 .get()
-                                 .assertStatusCode(401));
-
-
-    // Missing JWT w/ Bearer scheme, no space after scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "Bearer")
-                                 .get()
-                                 .assertStatusCode(401));
-
-    // Bad JWT w/ Bearer scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "Bearer Foo")
-                                 .get()
-                                 .assertStatusCode(401));
-
-    // Missing JWT w/ JWT scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT ")
-                                 .get()
-                                 .assertStatusCode(401));
-
-
-    // Missing JWT w/ JWT scheme, no space after scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT")
-                                 .get()
-                                 .assertStatusCode(401));
-
-    // Bad JWT w/ JWT scheme
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT Foo")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtDisabledJwtAuthentication() throws Exception {
-    // Send in a JWT Authorization header when the Action has JWT disabled. Should always get a 401. When a JWT is provided, the action expects JWT to be enabled.
-    test.simulate(() -> simulator.test("/jwt-authorized-disabled")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertStatusCode(401));
-
-    // Same, use Bearer scheme
-    test.simulate(() -> simulator.test("/jwt-authorized-disabled")
-                                 .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtExpired() throws Exception {
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withURLParameter("authorized", true)
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NDUxMDA3MzF9.K18gIegEBfxgj8rU4D2WDh3CzEmRUmy8qBS7SWAcG9w")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtInvalidSignature() throws Exception {
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withURLParameter("authorized", true)
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.aaabbbcccddd")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtMissingAuthorizeHeader() throws Exception {
-    JwtAuthorizedAction.authorized = true;
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtNotAuthorized() throws Exception {
-    JwtAuthorizedAction.authorized = false;
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwtNotBefore() throws Exception {
-    // Validating the JWT registered claim 'nbf' (Not Before). The JWT is validly signed, but it is instructed not to be valid before some point in the future. Expecting a 401.
-    JwtAuthorizedAction.authorized = true;
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYmYiOjQ2MzIzOTY2NjV9.mRvvyJXvDD8RQ_PM1TadZdZNYXRa9CjOx62Tk866538")
-                                 .get()
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_jwt_jwtEnabled_deprecated() throws Exception {
-    // Test an action using the deprecated jwtEnabled instead of the jwt scheme
-    test.simulate(() -> simulator.test("/jwt-authorized-deprecated")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void get_jwt_other_scheme() throws Exception {
-    // Test an action with a jwt based scheme, but not named 'jwt'
-    test.simulate(() -> simulator.test("/jwt-authorized-other")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void get_largeFTL() {
-    simulator.test("/large-ftl")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("large FTL");
-  }
-
-  @Test
-  public void get_fieldMessage() throws Exception {
-    test.simulate(() -> simulator.test("/field-message")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertFieldHasNoErrors("foo")
-                                 .assertFieldHasNoErrors("bar")
-                                 .custom(r -> assertThrows(AssertionError.class, () -> r.assertFieldHasNoErrors("baz")))
-                                 .assertFieldHasErrorMessage("baz", "baz has an error")
-                                 .assertFieldHasErrorMessageFromKey("baz", "[ERROR]", "baz")
-                                 .assertFieldHasErrorCode("baz", "[ERROR]baz"));
-  }
-
-  @Test
-  public void get_message_callback() throws Exception {
-    // call an action that adds messages that calls another action that adds messages to ensure we can assert on the message store properly.
-    test.simulate(() -> simulator.test("/callback")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertContainsGeneralMessageCodes(MessageType.ERROR, "[ERROR]")
-                                 .assertContainsGeneralMessageCodes(MessageType.INFO, "[INFO]")
-                                 .assertContainsGeneralMessageCodes(MessageType.WARNING, "[WARNING]"));
-  }
-
-  @Test
-  public void get_metrics() throws Exception {
-    simulator.test("/user/full-form")
-             .get()
-             .assertBody(Files.readString(Path.of("src/test/resources/html/full-form.html")).trim());
-
-    Map<String, Timer> timers = metricRegistry.getTimers();
-    assertEquals(timers.get("prime-mvc.[/user/full-form].requests").getCount(), 1);
-    assertEquals(timers.get("prime-mvc.[*].requests").getCount(), 1);
-  }
-
-  @Test
-  public void get_metricsErrors() {
-    simulator.test("/execute-method-throws-exception")
-             .get()
-             .assertStatusCode(500);
-
-    Map<String, Timer> timers = metricRegistry.getTimers();
-    assertEquals(timers.get("prime-mvc.[/execute-method-throws-exception].requests").getCount(), 1);
-
-    Map<String, Meter> meters = metricRegistry.getMeters();
-    assertEquals(meters.get("prime-mvc.[/execute-method-throws-exception].errors").getCount(), 1);
-    assertEquals(meters.get("prime-mvc.[*].errors").getCount(), 1);
-  }
-
-  @Test
-  public void get_modifyRequest() throws Exception {
-    // The Test HTTP request consumer will have added an HTTP request header.
-    simulator.test("/foo")
-             .get()
-             .assertStatusCode(200)
-             .custom(result -> assertEquals(result.request.getHeader("X-Test-HTTP-Request-Consumer"), "true"));
-  }
-
-  @Test
-  public void get_nested_parameters() throws Exception {
-    test.simulate(() -> simulator.test("/nested")
-                                 .withURLSegment("42")
-                                 .withURLSegment("99")
-                                 .withURLSegment("parameter")
-                                 .withURLSegment("foo")
-                                 .withURLSegment("bar")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Success!", "preParam1=42", "preParam2=99", "endParam1=foo", "endParam2=bar"));
-  }
-
-  @Test
-  public void get_nonFormFields() throws Exception {
-    simulator.test("/user/details-fields")
-             .get()
-             .assertBodyFile(Path.of("src/test/resources/html/details-fields.html"));
-  }
-
-  @Test
-  public void get_objectMapValues() throws Exception {
-    // Testing ?eval against a generic map
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains(
-                                     "Name:foo.data.preferences.coffee.style",
-                                     ":Value::Value:"));
-  }
-
-  @Test
-  public void get_onlyKnownParameters() throws Exception {
-    // Action w/out @UnknownParameters
-    configuration.allowUnknownParameters = false;
-    test.simulate(() -> simulator.test("/only-known-parameters")
-                                 .withParameter("foo", "bar")
-                                 .withParameter("foo", "baz")
-                                 .withParameter("foo.bar", "baz")
-                                 .withParameter("foo/0/bar/bam", "purple")
-                                 .post()
-                                 .assertStatusCode(500)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test
-  public void get_overrideClassNameForURI() throws Exception {
-    test.simulate(() -> simulator.test("/OverrideMe")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyIsEmpty());
-
-    assertTrue(OverrideMeAction.invoked);
-
-    // Reset
-    OverrideMeAction.invoked = false;
-
-    boolean succeeded = false;
-
-    try {
-      test.simulate(() -> simulator.test("/override-me")
-                                   .get()
-                                   .assertStatusCode(404)
-                                   .assertBodyIsEmpty());
-      succeeded = true;
-    } catch (Error expected) {
-    }
-
-    if (succeeded) {
-      fail("Expected a failure!");
-    }
-  }
-
-  @Test
-  public void get_percent_encoded_segment() throws Exception {
-    test.simulate(() -> simulator.test("/foo/view")
-                                 .withURLSegment("<strong>foo</strong>")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains("/foo/view!", "id=&lt;strong&gt;foo&lt;/strong&gt;"));
-
-    test.simulate(() -> simulator.test("/foo/view/%3Cstrong%3Efoo%3C%2Fstrong%3E")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("/foo/view!", "id=&lt;strong&gt;foo&lt;/strong&gt;"));
-  }
-
-  @Test
-  public void get_postParameterBeforeFormPrepare() throws Exception {
-    // Ensure we hit PostParameterMethods in an action when we build a new action based upon hitting a
-    // form tag that has a different action then the current action invocation.
-
-    test.simulate(() -> simulator.test("/scope/page-two")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertBodyContains("postParameterMethodCalled:first")
-                                 .assertBodyContains("formPrepareMethodCalled:second"))
-
-        // Now hit /api/page-one which contains a form tag with an action of /scope/page-two
-        .simulate(() -> simulator.test("/scope/page-one")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("postParameterMethodCalled:first")
-                                 .assertBodyContains("formPrepareMethodCalled:second"));
-  }
-
-  @Test
-  public void get_preRender() {
-    simulator.test("/pre-render-method")
-             .withURLParameter("result", "forward")
-             .get()
-             .assertStatusCode(200)
-             .assertContentType("text/html; charset=UTF-8")
-             .assertBodyContains("Forward_Yep!", "JSON_Nope!", "Noop_Nope!");
-
-    simulator.test("/pre-render-method")
-             .withURLParameter("result", "json")
-             .get()
-             .assertStatusCode(200)
-             .assertContentType("application/json; charset=UTF-8")
-             .assertBodyContains("trust me it is json");
-
-    simulator.test("/pre-render-method")
-             .withURLParameter("result", "noop")
-             .get()
-             .assertStatusCode(201)
-             .assertContentType("application/potato")
-             .assertBodyContains("You've been no-oped!");
-  }
-
-  @Test
-  public void get_redirect() throws Exception {
-    // Contains no parameters
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/foo"));
-
-    // Contains a single parameter, calling beginQuery is optional
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo?bar=baz")
-                                 .assertRedirect("/foo", params -> params.with("bar", "baz")));
-
-    // Contains a single parameter with calling beginQuery()
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo?bar=baz")
-                                 .assertRedirect("/foo", params -> params.beginQuery()
-                                                                         .with("bar", "baz")));
-
-    // Contains multiple parameters
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz&boom=dynamite")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo?bar=baz&boom=dynamite")
-                                 .assertRedirect("/foo", params -> params.beginQuery()
-                                                                         .with("bar", "baz")
-                                                                         .with("boom", "dynamite")));
-
-    // Contains a single parameter after a fragment
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo#bar=baz")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo#bar=baz")
-                                 .assertRedirect("/foo", params -> params.beginFragment()
-                                                                         .with("bar", "baz")));
-
-    // Contains multiple parameters after a fragment
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo#bar=baz&boom=dynamite")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo#bar=baz&boom=dynamite")
-                                 .assertRedirect("/foo", params -> params.beginFragment()
-                                                                         .with("bar", "baz")
-                                                                         .with("boom", "dynamite")));
-
-    // Contains a single parameter and a single parameter after a fragment
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz#middle=out")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo?bar=baz#middle=out")
-                                 .assertRedirect("/foo", params -> params.beginQuery()
-                                                                         .with("bar", "baz")
-                                                                         .beginFragment()
-                                                                         .with("middle", "out")));
-
-    // Contains multiple parameters and multiple parameters after a fragment
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz&boom=dynamite#middle=out&not=hotdog")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/foo?bar=baz&boom=dynamite#middle=out&not=hotdog")
-                                 .assertRedirect("/foo", params -> params.beginQuery()
-                                                                         .with("bar", "baz")
-                                                                         .with("boom", "dynamite")
-                                                                         .beginFragment()
-                                                                         .with("middle", "out")
-                                                                         .with("not", "hotdog")));
-
-    // URL has multiple parameters
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bar=baz&q=foo&code=bar")
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/foo?bar=baz&q=foo&code=bar")
-                                 .assertRedirect("/foo", params -> params.beginQuery()
-                                                                         .with("bar", "baz")
-                                                                         .with("q", "foo")
-                                                                         .with("code", "bar")));
-
-    // When we expect parameters, assert that the URL does not have parameters. This tests for an edge case
-    // that we have fixed in the RequestResult.
-    try {
-      test.simulate(() -> simulator.test("/complex-redirect")
-                                   .withURLParameter("redirectURI", "/foo?bar=baz&q=foo&code=bar")
-                                   .get()
-                                   .assertStatusCode(302)
-                                   .assertRedirect("/foo"));
-      fail("Expected a failure.");
-    } catch (Error e) {
-      assertEquals(e.getClass(), AssertionError.class);
-    }
-  }
-
-  @Test
-  public void get_redirect_flash_scope_messageLookup() throws Exception {
-    // Use case, see if we can correctly assert on a message key in a body when the message only exists in a bundle for the initial action
-    simulator.test("/flash-scope/redirect")
-             .get()
-             .assertStatusCode(302)
-             .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
-             .assertRedirect("/flash-scope/")
-             .executeRedirectReturnResult(result -> result.assertStatusCode(200)
-                                                          .assertContainsGeneralMessageCodes(MessageType.INFO, "[FlashScopeMessageKey]")
-                                                          .assertBodyContainsMessagesFromKey("[FlashScopeMessageKey]")
-                                                          .assertBody("""
-                                                                          This is an index page.
-                                                                          
-                                                                            Info:This is a message!
-                                                                          
-                                                                          """)
-             );
-  }
-
-  @Test
-  public void get_redirect_withActual() throws Exception {
-    // Contains no parameters
-    test.simulate(() -> simulator.test("/complex-redirect")
-                                 .withURLParameter("redirectURI", "/foo?bing=bam&instant=" + System.currentTimeMillis())
-                                 .get()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/foo", params -> params.withActual("instant")
-                                                                         .with("bing", "bam")));
-  }
-
-  @Test
-  public void get_redirects_nested() throws Exception {
-    // See if we can nest many redirects
-    test.simulate(() -> simulator
-        .test("/router/redirect")
-        .get()
-        .assertStatusCode(302)
-        .assertRedirect("/router/redirect/1")
-        .followRedirect(r1 -> r1
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/2")
-            .followRedirect(r2 -> r2
+        // Mix it up, go deep but not all the way
+        test.simulate(() -> simulator
+                .test("/router/redirect/")
+                .get()
                 .assertStatusCode(302)
-                .assertRedirect("/router/redirect/3")
-                .followRedirect(r3 -> r3
-                    .assertStatusCode(302)
-                    .assertRedirect("/router/redirect/4")
-                    .followRedirect(r4 -> r4
+                .assertRedirect("/router/redirect/1")
+                .followRedirect(r1 -> r1
                         .assertStatusCode(302)
-                        .assertRedirect("/router/redirect/5")
-                        .followRedirect(r5 -> r5
-                            .assertStatusCode(200)
-                            .assertBodyIsEmpty()))))));
+                        .assertRedirect("/router/redirect/2")
+                        .followRedirect(r2 -> r2
+                                .assertStatusCode(302)
+                                .assertRedirect("/router/redirect/3")
+                                .followRedirect(r3 -> r3
+                                        .assertStatusCode(302)
+                                        .assertRedirect("/router/redirect/4")
+                                        .followRedirect(r4 -> r4
+                                                .assertStatusCode(302)
+                                                .assertRedirect("/router/redirect/5")))))
+                .followRedirect(r5 -> r5
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty())
+        );
 
-    // See if we can be more civilized and come back out to the top level as well
-    test.simulate(() -> simulator
-        .test("/router/redirect")
-        .get()
-        .assertStatusCode(302)
-        .assertRedirect("/router/redirect/1")
-        .followRedirect(r1 -> r1
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/2"))
-        .followRedirect(r2 -> r2
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/3"))
-        .followRedirect(r3 -> r3
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/4"))
-        .followRedirect(r4 -> r4
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/5"))
-        .followRedirect(r5 -> r5
-            .assertStatusCode(200)
-            .assertBodyIsEmpty())
-    );
-
-    // Mix it up, go deep but not all the way
-    test.simulate(() -> simulator
-        .test("/router/redirect/")
-        .get()
-        .assertStatusCode(302)
-        .assertRedirect("/router/redirect/1")
-        .followRedirect(r1 -> r1
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/2")
-            .followRedirect(r2 -> r2
-                .assertStatusCode(302)
-                .assertRedirect("/router/redirect/3")
-                .followRedirect(r3 -> r3
-                    .assertStatusCode(302)
-                    .assertRedirect("/router/redirect/4")
-                    .followRedirect(r4 -> r4
+        // Mix in a submitForm
+        test.simulate(() -> simulator
+                .test("/router/submit-form")
+                .get()
+                .assertStatusCode(200)
+                .assertHTML(html -> html.assertElementExists("form"))
+                .submitForm("form", r1 -> r1
                         .assertStatusCode(302)
-                        .assertRedirect("/router/redirect/5")))))
-        .followRedirect(r5 -> r5
-            .assertStatusCode(200)
-            .assertBodyIsEmpty())
-    );
+                        .assertRedirect("/router/redirect/1")
+                        .followRedirect(r2 -> r2
+                                .assertStatusCode(302)
+                                .assertRedirect("/router/redirect/2")
+                                .followRedirect(r3 -> r3
+                                        .assertStatusCode(302)
+                                        .assertRedirect("/router/redirect/3")
+                                        .followRedirect(r4 -> r4
+                                                .assertStatusCode(302)
+                                                .assertRedirect("/router/redirect/4")
+                                                .followRedirect(r5 -> r5
+                                                        .assertStatusCode(302)
+                                                        .assertRedirect("/router/redirect/5")))))
+                        .followRedirect(r6 -> r6
+                                .assertStatusCode(200)
+                                .assertBodyIsEmpty())
+                )
+        );
 
-    // Mix in a submitForm
-    test.simulate(() -> simulator
-        .test("/router/submit-form")
-        .get()
-        .assertStatusCode(200)
-        .assertHTML(html -> html.assertElementExists("form"))
-        .submitForm("form", r1 -> r1
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/1")
-            .followRedirect(r2 -> r2
+        // Mix in a metaRefresh
+        test.simulate(() -> simulator
+                .test("/router/meta-refresh")
+                .get()
+                .assertStatusCode(200)
+                .assertHTML(html -> html.assertElementExists("meta[http-equiv=Refresh]"))
+                .followMetaRefresh(r1 -> r1
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/1")
+                        .followRedirect(r2 -> r2
+                                .assertStatusCode(302)
+                                .assertRedirect("/router/redirect/2")
+                                .followRedirect(r3 -> r3
+                                        .assertStatusCode(302)
+                                        .assertRedirect("/router/redirect/3"))
+                                .followRedirect(r4 -> r4
+                                        .assertStatusCode(302)
+                                        .assertRedirect("/router/redirect/4")
+                                        .followRedirect(r5 -> r5
+                                                .assertStatusCode(302)
+                                                .assertRedirect("/router/redirect/5"))))
+                        .followRedirect(r6 -> r6
+                                .assertStatusCode(200)
+                                .assertBodyIsEmpty())
+                )
+        );
+
+        // Perform assertions on top-level
+        test.simulate(() -> simulator
+                .test("/router/meta-refresh")
+                .get()
+                .assertStatusCode(200)
+                .assertHTML(html -> html.assertElementExists("meta[http-equiv=Refresh]"))
+
+                // top-level
+                .followMetaRefresh()
                 .assertStatusCode(302)
-                .assertRedirect("/router/redirect/2")
-                .followRedirect(r3 -> r3
-                    .assertStatusCode(302)
-                    .assertRedirect("/router/redirect/3")
-                    .followRedirect(r4 -> r4
+                .assertRedirect("/router/redirect/1")
+
+                // nested
+                .followRedirect(r2 -> r2
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/2")
+                        .followRedirect()
+                        .assertStatusCode(302)
+                        .assertRedirect("/router/redirect/3"))
+                .followRedirect(r4 -> r4
                         .assertStatusCode(302)
                         .assertRedirect("/router/redirect/4")
                         .followRedirect(r5 -> r5
-                            .assertStatusCode(302)
-                            .assertRedirect("/router/redirect/5")))))
-            .followRedirect(r6 -> r6
+                                .assertStatusCode(302)
+                                .assertRedirect("/router/redirect/5")))
+
+                // top-level
+                .followRedirect()
                 .assertStatusCode(200)
-                .assertBodyIsEmpty())
-        )
-    );
+                .assertBodyIsEmpty()
 
-    // Mix in a metaRefresh
-    test.simulate(() -> simulator
-        .test("/router/meta-refresh")
-        .get()
-        .assertStatusCode(200)
-        .assertHTML(html -> html.assertElementExists("meta[http-equiv=Refresh]"))
-        .followMetaRefresh(r1 -> r1
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/1")
-            .followRedirect(r2 -> r2
-                .assertStatusCode(302)
-                .assertRedirect("/router/redirect/2")
-                .followRedirect(r3 -> r3
-                    .assertStatusCode(302)
-                    .assertRedirect("/router/redirect/3"))
-                .followRedirect(r4 -> r4
-                    .assertStatusCode(302)
-                    .assertRedirect("/router/redirect/4")
-                    .followRedirect(r5 -> r5
-                        .assertStatusCode(302)
-                        .assertRedirect("/router/redirect/5"))))
-            .followRedirect(r6 -> r6
-                .assertStatusCode(200)
-                .assertBodyIsEmpty())
-        )
-    );
-
-    // Perform assertions on top-level
-    test.simulate(() -> simulator
-        .test("/router/meta-refresh")
-        .get()
-        .assertStatusCode(200)
-        .assertHTML(html -> html.assertElementExists("meta[http-equiv=Refresh]"))
-
-        // top-level
-        .followMetaRefresh()
-        .assertStatusCode(302)
-        .assertRedirect("/router/redirect/1")
-
-        // nested
-        .followRedirect(r2 -> r2
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/2")
-            .followRedirect()
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/3"))
-        .followRedirect(r4 -> r4
-            .assertStatusCode(302)
-            .assertRedirect("/router/redirect/4")
-            .followRedirect(r5 -> r5
-                .assertStatusCode(302)
-                .assertRedirect("/router/redirect/5")))
-
-        // top-level
-        .followRedirect()
-        .assertStatusCode(200)
-        .assertBodyIsEmpty()
-
-    );
-  }
-
-  @Test
-  public void get_secure() throws Exception {
-    test.simulate(() -> simulator.test("/secure")
-                                 .get()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(401));
-  }
-
-  @Test
-  public void get_template_noAction() throws Exception {
-    // Ok
-    simulator.test("/freemarker/stand-alone-template")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Yo, nice template.");
-
-    // uses a message key that's not found
-    simulator.test("/freemarker/missing-message-template")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Yo, nice template.", "the default message");
-
-    // Double slash, redirect to the correct location
-    simulator.test("/freemarker//stand-alone-template")
-             .get()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Yo, nice template.");
-
-    // Triple slashes, redirect to the correct location
-    simulator.test("/freemarker///stand-alone-template")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Yo, nice template.");
-
-    // Double slash, on two paths, redirect to the correct location
-    simulator.test("/freemarker//sub//stand-alone-template")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Yo, nice sub-directory template.");
-
-    try {
-      // Invalid path, double slash, redirect, still invalid.
-      simulator.test("/freemarker//does-not-exist")
-               .get()
-               .assertStatusCode(301)
-               .assertRedirect("/freemarker/does-not-exist");
-      fail("Expected a failure.");
-    } catch (Error e) {
-      assertEquals(e.getClass(), AssertionError.class);
+        );
     }
 
-    try {
-      // Index template, ensure we clean up the '/index/ suffix that will get added during action mapping
-      simulator.test("/freemarker/sub//")
-               .get()
-               .assertStatusCode(301)
-               .assertRedirect("/freemarker/sub/")
-               // A 301 will not contain these headers
-               .assertHeaderDoesNotContain("Cache-Control")
-               .executeRedirect(result -> result.assertStatusCode(200)
-                                                .assertBodyContains("Yo, nice sub-directory index template."));
-      fail("Expected a failure.");
-    } catch (Error e) {
-      assertEquals(e.getClass(), AssertionError.class);
+    @Test
+    public void get_secure() throws Exception {
+        test.simulate(() -> simulator.test("/secure")
+                .get()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(401));
     }
-  }
 
-  @Test
-  public void get_underscore() {
-    simulator.test("/test_underscore")
-             .get()
-             .assertStatusCode(200);
-  }
+    @Test
+    public void get_template_noAction() throws Exception {
+        // Ok
+        simulator.test("/freemarker/stand-alone-template")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Yo, nice template.");
 
-  @Test
-  public void get_unknownParameters() throws Exception {
-    configuration.allowUnknownParameters = false;
-    test.simulate(() -> simulator.test("/unknown-parameters")
-                                 .withParameter("foo", "bar")
-                                 .withParameter("foo", "baz")
-                                 .withParameter("foo.bar", "baz")
-                                 .withParameter("foo/0/bar/bam", "purple")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains(
-                                     "foo => [bar,baz]",
-                                     "foo.bar => [baz]",
-                                     "foo/0/bar/bam => [purple]"
-                                 ));
-  }
+        // uses a message key that's not found
+        simulator.test("/freemarker/missing-message-template")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Yo, nice template.", "the default message");
 
-  @Test
-  public void get_url_rewrite() {
-    // Ensure a legacy configuration no longer has any affect on the request mapper.
-    simulator.test("/doesNotExist?__a_foo=/user/edit&foo=true")
-             .get()
-             .assertStatusCode(404)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("The page is missing!");
-    assertFalse(EditAction.getCalled);
-  }
+        // Double slash, redirect to the correct location
+        simulator.test("/freemarker//stand-alone-template")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Yo, nice template.");
 
-  @Test
-  public void get_wellKnownDotPrefixed() throws Exception {
-    test.simulate(() -> simulator.test("/.well-known/openid-configuration")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertJSON("{\"called\": \"/.well-known/openid-configuration\"}"));
+        // Triple slashes, redirect to the correct location
+        simulator.test("/freemarker///stand-alone-template")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Yo, nice template.");
 
-    // The nested directory does not have a package-modifier, so we will get the actual path of 'well-known' instead of '.well-known'.
-    test.simulate(() -> simulator.test("/.well-known/well-known/openid-configuration")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertJSON("{\"called\": \"/.well-known/well-known/openid-configuration\"}"));
+        // Double slash, on two paths, redirect to the correct location
+        simulator.test("/freemarker//sub//stand-alone-template")
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Yo, nice sub-directory template.");
 
-    // Testing two levels deep, but only the 1st and 3rd level have a package modifier.
-    // .well-known -> well-known -> .well-known. The package modifier causes us to ignore the 'potato' package name.
-    test.simulate(() -> simulator.test("/.well-known/well-known/.well-known/openid-configuration")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertJSON("{\"called\": \"/.well-known/well-known/potato/openid-configuration\"}"));
-
-    // This is an invalid mapping, so it will result in a 404
-    test.simulate(() -> simulator.test("/.well-known/.well-known/openid-configuration")
-                                 .get()
-                                 .assertStatusCode(404));
-  }
-
-  @Test
-  public void hacked() {
-    // Make sure we don't invoke "freemarker.template.utility.Execute"
-    simulator.test("/hacked")
-             .get()
-             .assertStatusCode(500)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Instantiating freemarker.template.utility.Execute is not allowed in the template for security reasons.");
-  }
-
-  @Test
-  public void headers() throws IOException {
-    // Make sure multiple headers with the same name get returned
-    simulator.test("/header-values")
-        .withHeader("foo", "bar")
-        .withHeader("foo", "baz")
-        .get()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/foo", List.of("bar", "baz"));
-  }
-
-  @Test
-  public void headers_withHeaderIfPresent() throws IOException {
-    // Null value should not add the header
-    simulator.test("/header-values")
-             .withHeaderIfPresent("foo", null)
-             .get()
-             .assertStatusCode(200)
-             .assertJSONValuesAt("/foo", null);
-
-    // Non-null value should add the header
-    simulator.test("/header-values")
-             .withHeaderIfPresent("foo", "bar")
-             .get()
-             .assertStatusCode(200)
-             .assertJSONValuesAt("/foo", List.of("bar"));
-  }
-
-  @Test
-  public void dpopHeader() throws IOException {
-    // Make sure DPoPProofProvider gets invoked with proper values
-    // (a real DPoPProofProvider would generate a signed JWT)
-    DPoPProofProvider provider = (httpMethod, htu, accessToken) -> httpMethod.toString() + ":" + htu + ":" + accessToken;
-
-    simulator.test("/header-values")
-        .withDPoPProofProvider(provider)
-        .get()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/dpop", List.of("GET:http://localhost:9080/header-values:null"));
-
-    simulator.test("/header-values")
-        .withDPoPProofProvider(provider)
-        .withAuthorizationDPoPToken("fake.token")
-        .get()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/authorization", List.of("DPoP fake.token"))
-        .assertJSONValuesAt("/dpop", List.of("GET:http://localhost:9080/header-values:fake.token"));
-
-    simulator.test("/header-values")
-        .withDPoPProofProvider(provider)
-        .post()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/dpop", List.of("POST:http://localhost:9080/header-values:null"));
-
-    simulator.test("/header-values")
-        .withDPoPProofProvider(provider)
-        .withAuthorizationDPoPToken("fake.token")
-        .post()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/authorization", List.of("DPoP fake.token"))
-        .assertJSONValuesAt("/dpop", List.of("POST:http://localhost:9080/header-values:fake.token"));
-  }
-
-  @Test
-  public void bearerTokenAuthHeader() throws IOException {
-    // Exercise the withAuthorizationBearerToken() call
-
-    simulator.test("/header-values")
-        .withAuthorizationBearerToken("fake.token")
-        .get()
-        .assertStatusCode(200)
-        .assertJSONValuesAt("/authorization", List.of("Bearer fake.token"));
-  }
-
-  @Test(expectedExceptions = IllegalStateException.class)
-  public void bearerTokenAndDPoPTokenAuthHeader() throws IOException {
-    // Ensure we can't call withAuthorizationBearerToken() and withAuthorizationDPoPToken()
-
-    simulator.test("/header-values")
-        .withAuthorizationBearerToken("fake.bearer.token")
-        .withAuthorizationDPoPToken("fake.dpop.token");
-  }
-
-  @Test
-  public void head() {
-    simulator.test("/head")
-             .head()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyIsEmpty();
-  }
-
-  @Test
-  public void head_jwtAuthorized() throws Exception {
-    // This test will pass if we call the JWT authorize method or not....
-    JwtAuthorizedAction.authorized = true;
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .head()
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void head_jwtNotAuthorized() throws Exception {
-    JwtAuthorizedAction.authorized = false;
-    test.simulate(() -> simulator.test("/jwt-authorized")
-                                 .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
-                                 .head()
-                                 .assertStatusCode(401)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test(enabled = false)
-  public void manual_tooManyOpenFiles() throws Exception {
-    // Cause a connection reset to the HTTP server, and only close every 100th connection.
-    // - This will cause the connection reset and eventually also cause a 'Too many open files' exception.
-    for (int i = 0; i < 250_000; i++) {
-      if (i % 5_000 == 0) {
-        System.out.println("Iteration [" + i + "]....");
-      }
-
-      try {
-        Socket socket = new Socket();
-        socket.setSoLinger(true, 0);
-        socket.connect(new InetSocketAddress("localhost", 8080));
-        OutputStream os = socket.getOutputStream();
-        // Build an HTTP request body
-        os.write((
-                     "POST /inform HTTP/1.1\r\n" +
-                     "Host: 192.168.1.44:8080\r\n" +
-                     "Accept: */*\r\n" +
-                     "Content-Length: 8588\r\n" +
-                     "\r\n"
-                 ).getBytes(StandardCharsets.UTF_8));
-
-        os.flush();
-        if (i % 100 == 0) {
-          socket.close();
+        try {
+            // Invalid path, double slash, redirect, still invalid.
+            simulator.test("/freemarker//does-not-exist")
+                    .get()
+                    .assertStatusCode(301)
+                    .assertRedirect("/freemarker/does-not-exist");
+            fail("Expected a failure.");
+        } catch (Error e) {
+            assertEquals(e.getClass(), AssertionError.class);
         }
 
-      } catch (Exception e) {
-        System.out.println("[Test Exception] [" + e.getMessage() + "]");
-      }
+        try {
+            // Index template, ensure we clean up the '/index/ suffix that will get added during action mapping
+            simulator.test("/freemarker/sub//")
+                    .get()
+                    .assertStatusCode(301)
+                    .assertRedirect("/freemarker/sub/")
+                    // A 301 will not contain these headers
+                    .assertHeaderDoesNotContain("Cache-Control")
+                    .executeRedirect(result -> result.assertStatusCode(200)
+                            .assertBodyContains("Yo, nice sub-directory index template."));
+            fail("Expected a failure.");
+        } catch (Error e) {
+            assertEquals(e.getClass(), AssertionError.class);
+        }
     }
 
-    boolean finish = false;
-    while (!finish) {
-      System.out.println("Waiting.... kill the test, or pause the debugger and set finish = true.");
-      Thread.sleep(10_000);
+    @Test
+    public void get_underscore() {
+        simulator.test("/test_underscore")
+                .get()
+                .assertStatusCode(200);
     }
-  }
 
-  @Test
-  public void missing() {
-    // Direct action invocation
-    simulator.test("/missing")
-             .get()
-             .assertStatusCode(404)
-             .assertBodyContains("The page is missing!");
-
-    // A traditional 404
-    simulator.test("/also-missing")
-             .get()
-             .assertStatusCode(404)
-             .assertBodyContains("The page is missing!");
-  }
-
-  @Test
-  public void multipleJSONRequestMembers() throws Exception {
-    simulator.test("/multiple-json-request")
-             .post()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache");
-
-    simulator.test("/multiple-json-request")
-             .withJSON(new Object())
-             .post()
-             .assertStatusCode(201)
-             .assertHeaderContains("Cache-Control", "no-cache");
-
-    simulator.test("/multiple-json-request")
-             .withJSON(new Object())
-             .delete()
-             .assertStatusCode(202)
-             .assertHeaderContains("Cache-Control", "no-cache");
-  }
-
-  @Test
-  public void notAllowed() {
-    simulator.test("/not-allowed")
-             .get()
-             .assertStatusCode(405)
-             .assertHeaderContains("Cache-Control", "no-cache");
-
-    simulator.test("/not-allowed")
-             .post()
-             .assertStatusCode(405);
-
-    simulator.test("/not-allowed")
-             .put()
-             .assertStatusCode(405);
-
-    simulator.test("/not-allowed")
-             .delete()
-             .assertStatusCode(405);
-
-    // head is allowed
-    simulator.test("/not-allowed")
-             .head()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache");
-  }
-
-  @Test
-  public void notImplemented() {
-    simulator.test("/not-allowed")
-             .method("POTATO")
-             // We currently only map out execute methods in the action that are named by a method
-             // defined in the HTTPMethod.StandardMethods. If an action does not define a standard HTTP
-             // method, a 405 will be returned. If you ask for a non-standard method that is not implemented
-             // by prime-mvc, you will receive a 501.
-             .assertStatusCode(501)
-             .assertHeaderContains("Cache-Control", "no-cache");
-  }
-
-  @Test
-  public void parameter_order_of_operation() throws Exception {
-    // Test the order of operation when we have parameters in a body, URI segment, and query string.
-
-    // Provide segment, body and parameter, additive - parameter + body
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLSegment("segment")
-                                 .withURLParameter("value", "parameter")
-                                 .withContentType("application/x-www-form-urlencoded")
-                                 .withBody("""
-                                               value=body
-                                               """)
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:parameter,body"));
-
-    // Segment and parameter, parameter wins
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLSegment("segment")
-                                 .withURLParameter("value", "parameter")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:parameter"));
-
-    // Segment and body, body wins
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLSegment("segment")
-                                 .withContentType("application/x-www-form-urlencoded")
-                                 .withBody("""
-                                               value=body
-                                               """)
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:body"));
-
-    // Parameter and body, additive - parameter + body
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLParameter("value", "parameter")
-                                 .withContentType("application/x-www-form-urlencoded")
-                                 .withBody("""
-                                               value=body
-                                               """)
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:parameter,body"));
-
-    // Body only, body
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withContentType("application/x-www-form-urlencoded")
-                                 .withBody("""
-                                               value=body
-                                               """)
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:body"));
-
-    // Segment only, segment
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLSegment("segment")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:segment"));
-
-    // Parameter only, parameter
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withURLParameter("value", "parameter")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("value:parameter"));
-  }
-
-  @Test
-  public void post() {
-    simulator.test("/post")
-             .post()
-             .assertStatusCode(200)
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertBodyContains("Brian Pontarelli", "35", "Broomfield", "CO");
-  }
-
-  @Test
-  public void post_JSONWithActual() throws Exception {
-    simulator.test("/api")
-             .withJSONFile(Path.of("src/test/resources/json/api-jsonWithActual-post.json"))
-             .post()
-             .assertHeaderContains("Cache-Control", "no-cache")
-             .assertJSONFileWithActual(UserField.class, Path.of("src/test/resources/json/api-jsonWithActual-post-response.ftl"));
-
-    // Test a final field (the Jackson handler will put the JSON into the final field)
-    simulator.test("/api-final")
-             .withJSONFile(Path.of("src/test/resources/json/api-jsonWithActual-post.json"))
-             .post()
-             .assertJSONFileWithActual(UserField.class, Path.of("src/test/resources/json/api-jsonWithActual-post-response.ftl"));
-  }
-
-  @Test
-  public void post_anyContentType() throws Exception {
-    test.createFile("Hello World")
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataAnyType", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"))
-
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataAnyType", test.tempFile, "text/html")
-                                 .post()
-                                 .assertStatusCode(200))
-
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataAnyType", test.tempFile, "application/octet-stream")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test
-  public void post_apiJSONBothWays() throws Exception {
-    Path jsonFile = Path.of("src/test/resources/json/api-jsonBothWays-post.json");
-    simulator.test("/api")
-             .withJSONFile(jsonFile)
-             .post()
-             .assertJSONFile(jsonFile);
-  }
-
-  @Test
-  public void post_binary() throws Exception {
-    test.simulate(() -> simulator.test("/binary")
-                                 .withURLParameter("expected", "Hello World")
-                                 .withBody("Hello World")
-                                 .withContentType("application/octet-stream")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test
-  public void post_binary_no_body() throws Exception {
-    test.simulate(() -> simulator.test("/binary")
-                                 .withURLParameter("expectedNullFile", "true")
-                                 .withContentType("application/octet-stream")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertHeaderContains("Cache-Control", "no-cache"));
-  }
-
-  @Test
-  public void post_chunked_json() throws Exception {
-    // Our simulator does not chunk. This test uses the Java HTTP client to test chunking with Content-Type: application/json
-    HttpClient client = HttpClient.newBuilder()
-                                  .connectTimeout(Duration.of(500, ChronoUnit.MILLIS))
-                                  .build();
-
-    var response = client.send(
-        HttpRequest.newBuilder()
-                   .uri(URI.create("http://localhost:9080/api"))
-                   .header(Headers.ContentType, "application/json")
-                   .POST(BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(readBytes("src/test/resources/json/api-jsonWithActual-post.json"))))
-                   .build(),
-        r -> BodySubscribers.ofString(StandardCharsets.UTF_8)
-    );
-
-    assertEquals(response.statusCode(), 200);
-  }
-
-  @Test
-  public void post_collectionConverter() throws Exception {
-    // Single string containing commas, output contains the same string
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withParameter("strings", "foo,bar,baz")
-                                 .post()
-                                 .assertStatusCode(200));
-
-    // Multiple values, output contains these two values in a collection
-    test.simulate(() -> simulator.test("/collection-converter")
-                                 .withParameter("strings", "bar")
-                                 .withParameter("strings", "baz")
-                                 .post()
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void post_cookies() throws Exception {
-    // Test cookie propagation between invocations within the same test
-    test.simulate(() -> simulator.test("/cookie")
-                                 .withParameter("name", "token")
-                                 .withParameter("value", "secret")
-                                 .withParameter("saveMe", "save a value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyIsEmpty()
-                                 // Assert the cookie is set
-                                 .assertCookie("token", "secret")
-                                 // Assert we dropped a cookie for the @BrowserActionSession
-                                 .assertContainsCookie("org.example.action.CookieAction$saveMe"))
-
-        // Now make a GET request to the same action and verify the cookies were picked up on the request.
-        .simulate(() -> simulator.test("/cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains(
-                                     "Count:2",
-                                     "token:secret",
-                                     "org.example.action.CookieAction$saveMe:") // the value will be encoded
-                                 // Cookie is not written back on this response
-                                 .assertDoesNotContainsCookie("token"))
-
-        // Clear the value set by @CookieAction by asking the action to set the value to 'null'
-        .simulate(() -> simulator.test("/cookie")
-                                 .withParameter("clearSaveMe", true)
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyIsEmpty()
-                                 // Cookie is written out with a null
-                                 .assertContainsCookie("org.example.action.CookieAction$saveMe"))
-
-        // Retrieve again, value will be gone.
-        .simulate(() -> simulator.test("/cookie")
-                                 .get()
-                                 .assertBodyContains(
-                                     "Count:1",
-                                     "token:secret")
-                                 .assertBodyDoesNotContain(
-                                     "org.example.action.CookieAction$saveMe:") // the value will be encoded
-                                 // Cookie is not written back on this response
-                                 .assertDoesNotContainsCookie("org.example.action.CookieAction$saveMe"))
-
-        // Set a generic type
-        .simulate(() -> simulator.test("/cookie")
-                                 .withParameter("u.bar", "baz")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyIsEmpty()
-                                 // Assert we dropped a cookie for the @BrowserActionSession
-                                 .assertContainsCookie("org.example.action.CookieAction$u"))
-
-        // Call get and see the value is set back into the action
-        .simulate(() -> simulator.test("/cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains(
-                                     "Count:2",
-                                     "token:secret",
-                                     "org.example.action.CookieAction$u:") // the value will be encoded
-                                 // Cookie is not written back on this response
-                                 .assertDoesNotContainsCookie("token"))
-
-        // Set a generic collection
-        .simulate(() -> simulator.test("/cookie")
-                                 .withParameter("list[0]bar", "bing")
-                                 .withParameter("list[1]bar", "boom")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyIsEmpty()
-                                 // Assert we dropped a cookie for the @BrowserActionSession
-                                 .assertContainsCookie("org.example.action.CookieAction$list"))
-
-        .simulate(() -> simulator.test("/cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains(
-                                     "Count:3",
-                                     "token:secret",
-                                     "org.example.action.CookieAction$list:", // the value will be encoded
-                                     "org.example.action.CookieAction$u:") // the value will be encoded
-                                 // Cookie is not written back on this response
-                                 .assertDoesNotContainsCookie("token"))
-
-        // Blow chunks and get an error in the message store that will use the cookie lash message scope.
-        .simulate(() -> simulator.test("/cookie")
-                                 .withURLParameter("blowChunks", true)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertContainsGeneralErrorMessageCodes("[CookieErrorException]")
-                                 .assertBodyContainsMessagesFromKey("[CookieErrorException]")
-                                 .assertBodyContains("Error count:1"))
-
-        // Add a message to the message store on a post / redirect and ensure we only end up with a single message in the store.
-        .simulate(() -> simulator.test("/cookie")
-                                 .withURLParameter("addMessage", true)
-                                 .post()
-                                 .assertStatusCode(302)
-                                 .assertRedirect("/cookie")
-                                 .assertContainsGeneralInfoMessageCodes("[NobodyDrinkTheBeer]")
-
-                                 // Execute the redirect and ensure we don't have duplicate messages
-                                 .executeRedirect(result -> result.assertStatusCode(200)
-                                                                  .assertBodyContains(
-                                                                      "Count:3",
-                                                                      "token:secret",
-                                                                      "org.example.action.CookieAction$list:", // the value will be encoded
-                                                                      "org.example.action.CookieAction$u:") // the value will be encoded
-                                                                  .assertContainsGeneralInfoMessageCodes("[NobodyDrinkTheBeer]")));
-  }
-
-  @Test
-  public void post_couldNotConvert() throws Exception {
-    // Could not convert, no specific message for key
-    test.simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap1['foo']", "bar")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap1['foo']")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[]"))
-
-        // Could not convert, specific message for this key
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap1['bar']", "baz")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap1['bar']")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1['bar']"))
-
-        // Could not convert, using generic message from Prime
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap2['baz']", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap2['baz']")
-                                 .assertBodyContains("Value Baz (java.lang.NumberFormatException: For input string: &quot;bing&quot;"))
-
-        // Unquoted versions
-
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap1[foo2]", "bar")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap1[foo2]")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[]"))
-
-        // Could not convert, specific message for this key
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap1[bar2]", "baz")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap1[bar2]")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[bar2]"))
-
-        // Could not convert, using generic message from Prime
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerMap2[baz2]", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerMap2[baz2]")
-                                 .assertBodyContains("Value Baz (java.lang.NumberFormatException: For input string: &quot;bing&quot;"))
-
-        // Numeric
-
-        // Could not convert, no specific message for this index in a list
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerList1[0]", "bar")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerList1[0]")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerList1[]"))
-
-        // Could not convert, specific message for this index in a list
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerList1[1]", "baz")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerList1[1]")
-                                 .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerList1[1]"))
-
-        // Could not convert, using generic message from Prime for the list
-        .simulate(() -> simulator.test("/could-not-convert")
-                                 .withParameter("integerList2[0]", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertContainsFieldErrors("integerList2[0]")
-                                 .assertBodyContains("List 2 - Int 1 (java.lang.NumberFormatException: For input string: &quot;bing&quot;"));
-  }
-
-  @Test
-  public void post_dateConversion() throws Exception {
-    // Multiple LocalDate formats
-    test.forEach(
-            "01-01-2018",
-            "01-01-2018",
-            "1-1-2018",
-            "1/01/2018",
-            "01/1/2018")
-        .test(date -> simulator.test("/date-time-converter")
-                               .withParameter("localDate", date)
-                               .withParameter("localDate@dateTimeFormat", "[MM/dd/yyyy][M/dd/yyyy][M/d/yyyy][MM-dd-yyyy][M-dd-yyyy][M-d-yyyy]")
-                               .post()
-                               .assertContainsNoFieldMessages()
-                               .assertStatusCode(200));
-
-    // Single LocalDate format
-    test.simulate(() -> simulator.test("/date-time-converter")
-                                 .withParameter("localDate", "01/01/2018")
-                                 .withParameter("localDate@dateTimeFormat", "MM/dd/yyyy")
-                                 .post()
-                                 .assertContainsNoFieldMessages()
-                                 .assertStatusCode(200));
-
-    // Multiple ZonedDateTime formats
-    test.forEach(
-            "07-08-2008 10:13:34 AM -0800",
-            "07/08/2008 10:13:34 AM -0800",
-            "7-8-2008 10:13:34 AM -0800",
-            "7/8/2008 10:13:34 AM -0800")
-        .test(zoneDateTime -> simulator.test("/date-time-converter")
-                                       .withParameter("zonedDateTime", zoneDateTime)
-                                       .withParameter("zonedDateTime@dateTimeFormat", "[MM-dd-yyyy hh:mm:ss a Z][MM/dd/yyyy hh:mm:ss a Z][M/d/yyyy hh:mm:ss a Z][M-d-yyyy hh:mm:ss a Z]")
-                                       .post()
-                                       .assertContainsNoFieldMessages()
-                                       .assertStatusCode(200));
-
-    // Single ZonedDateTime format
-    test.simulate(() -> simulator.test("/date-time-converter")
-                                 .withParameter("zonedDateTime", "07-08-2008 10:13:34 AM -0800")
-                                 .withParameter("zonedDateTime@dateTimeFormat", "MM-dd-yyyy hh:mm:ss a Z")
-                                 .post()
-                                 .assertContainsNoFieldMessages()
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void post_fieldNames() {
-    // Allow for unknown-parameters so that we can test runtime stuff.
-    configuration.allowUnknownParameters = true;
-
-    // Use annotation on a field and method
-    simulator.test("/field-name")
-             .withParameter("x-field", "value-field-a")
-             .withParameter("x-method", "value-method-a")
-             .withParameter("secondField", "value-field-b")
-             .withParameter("methodB", "value-method-b")
-             .withParameter("setfoo", "value-method-setfoo")
-             .withParameter("setBar", "value-method-setBar")
-             .withParameter("getBaz", "value-method-getBaz")
-             .withParameter("getboom", "value-method-getboom")
-             .withParameter("privateField", "value-private-field")
-             .withParameter("getValue", "value-method-getValue")
-             .withParameter("value2", "value-method-value2")
-             .withParameter("fieldA", "value-field-a-2")
-             .withParameter("fieldB", "value-field-b-2")
-             .post()
-             .assertStatusCode(200)
-             .assertBody("""
-                             fieldA:null
-                             fieldB:null
-                             fieldB:value-field-b
-                             methodA:value-method-a
-                             methodB:value-method-b
-                             methodC:null
-                             methodC:null
-                             foobar:null
-                             somethingElse1:value-method-setfoo
-                             somethingElse2:value-method-setBar
-                             somethingElse3:value-method-getBaz
-                             somethingElse4:value-method-getboom
-                             methodE:value-method-getBaz
-                             methodF:value-method-getboom
-                             methodG:value-method-getValue
-                             methodH:value-method-value2
-                             """);
-  }
-
-  @Test
-  public void post_fileUploadDisabled() throws Exception {
-    // File uploads are disabled by default, and unless the action annotates @FileUpload we should reject the request.
-    test.createFile("Hello World")
-        .simulate(() -> simulator.test("/no-files")
-                                 .withFile("dataAnyType", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(422))
-
-        // This action does not have an explicit mapping configured, but it should default.
-        .createFile("Hello World")
-        .simulate(() -> simulator.test("/no-files-no-result-mapping")
-                                 .withFile("dataAnyType", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(422));
-  }
-
-  @Test
-  public void post_file_tooLarge() throws Exception {
-    // File uploads are disabled by default, and unless the action annotates @FileUpload we should reject the request.
-    test.createFile("X".repeat(1024 * 1024 * 2))
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataAnyType", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(413));
-  }
-
-  // Test that the control behaves as expected
-  @Test
-  public void post_freemarker_escape() throws Exception {
-    simulator.test("/freemarker/escape")
-             .withParameter("listTest", "none")
-             .withParameter("listTest2", "none")
-             .post()
-             .assertStatusCode(200)
-             .assertHTML(html -> html.assertElementExists("input[name=listTest][value=none][checked]")
-                                     .assertElementExists("input[name=listTest2][value=none][checked]"));
-  }
-
-  @Test
-  public void post_fuzzing_invalid_expression() throws Exception {
-    // simulate a production runtime
-    configuration.allowUnknownParameters = true;
-    test.simulate(() -> simulator.test("/vanilla")
-                                 // This is an invalid expression, but unknown parameters are ignored.
-                                 .withParameter("class.method", "foo")
-                                 .post()
-                                 .assertStatusCode(200));
-
-    // simulate dev runtime
-    configuration.allowUnknownParameters = false;
-    test.simulate(() -> simulator.test("/vanilla")
-                                 // This is an invalid expression, an exception will be thrown and return a 500.
-                                 .withParameter("class.method", "foo")
-                                 .post()
-                                 .assertStatusCode(500));
-  }
-
-  @Test
-  public void post_generics() throws Exception {
-    test.simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "one")
-                                 .withParameter("typedObject.mapOfTypes[49e0f299-a2b0-4439-b0d5-3e2cc8949675].one", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Map one = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.mapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Map two = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.fullyGenericMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Map key/value = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.listOfStrings[0]", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("List string = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.listOfTypes[0].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("List two = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.singleString", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Single string = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.singleType.two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Single two = value"))
-
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "one")
-                                 .withParameter("typedObject.privateMapOfTypes[49e0f299-a2b0-4439-b0d5-3e2cc8949675].one", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private Map one = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private Map two = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateFullyGenericMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private Map key/value = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateListOfStrings[0]", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private List string = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateListOfTypes[0].two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private List two = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateSingleString", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private Single string = value"))
-        .simulate(() -> simulator.test("/generics")
-                                 .withParameter("type", "two")
-                                 .withParameter("typedObject.privateSingleType.two", "value")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("Private Single two = value"));
-  }
-
-  @Test
-  public void post_invalidJSON() throws Exception {
-    test.simulate(() -> simulator.test("/invalid-json")
-                                 .withJSONFile(Path.of("src/test/resources/json/InvalidJsonAction.json"))
-                                 .post()
-                                 .assertStatusCode(400)
-                                 .assertContainsFieldErrors("active")
-                                 // The actual exception seems to vary a bit, so instead we are asserting the content type and then that some specific info is in the body.
-                                 .assertContentType("application/json; charset=UTF-8")
-                                 .assertBodyContains(
-                                     "[invalidJSON]",
-                                     "Unable to parse JSON. The property [active] was invalid. The error was [Possible conversion error]. The detailed exception was ["));
-  }
-
-  @Test
-  public void post_jsonContentType() throws Exception {
-    // Content-Type: application/scim+json
-    simulator.test("/json-content-type")
-             .withContentType("application/test+json")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(400)
-             .assertJSON("""
-                             {
-                               "fieldErrors" : { },
-                               "generalErrors" : [ {
-                                 "code" : "[InvalidContentType]",
-                                 "message" : "Invalid [Content-Type] HTTP request header value of [application/test+json]. Supported values for this request include [application/json]."
-                               } ]
-                             }
-                             """);
-
-    // Patch not supported on this endpoint
-    simulator.test("/json-content-type-no-restriction")
-             .withContentType("application/json-patch+json")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(400)
-             .assertJSON("""
-                             {
-                               "fieldErrors" : { },
-                               "generalErrors" : [ {
-                                 "code" : "[PatchNotSupported]",
-                                 "message" : "The [Content-Type] HTTP request header value of [application/json-patch+json] is not supported for this request."
-                               } ]
-                             }
-                             """);
-
-    // Missing Content-Type Header
-    simulator.test("/json-content-type")
-             .withContentType("")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(400)
-             .assertJSON("""
-                              {
-                                "fieldErrors" : { },
-                                "generalErrors" : [ {
-                                  "code" : "[MissingContentType]",
-                                  "message" : "Missing required [Content-Type] HTTP request header."
-                                } ]
-                              }
-                             """);
-
-    // Supported Content-Type, but invalid for this request, however, because a body is provided, it will be allowed.
-    simulator.test("/json-content-type")
-             .withContentType("application/x-www-form-urlencoded")
-             .post()
-             .assertStatusCode(200)
-             .assertBodyIsEmpty();
-
-    // Not supported in general, but this action has restrictions, so we'll get a validation error.
-    simulator.test("/json-content-type")
-             .withContentType("application/klingon")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(400)
-             .assertJSON("""
-                             {
-                               "fieldErrors" : { },
-                               "generalErrors" : [ {
-                                 "code" : "[InvalidContentType]",
-                                 "message" : "Invalid [Content-Type] HTTP request header value of [application/klingon]. Supported values for this request include [application/json]."
-                               } ]
-                             }
-                             """);
-
-    // Not supported in general
-    simulator.test("/json-content-type-no-restriction")
-             .withContentType("application/klingon")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(400)
-             .assertJSON("""
-                              {
-                                "fieldErrors" : { },
-                                "generalErrors" : [ {
-                                  "code" : "[UnsupportedContentType]",
-                                      "message" : "Unsupported [Content-Type] HTTP request header value of [application/klingon]."
-                                } ]
-                              }
-                             """);
-
-    // Not supported in general, URL does not exist, a fuzzer. Expect a 404
-    simulator.test("/hack-the-planet")
-             .withContentType("application/klingon")
-             .withBody("""
-                           {
-                             "foo": "bar"
-                           }
-                           """)
-             .post()
-             .assertStatusCode(404)
-             .assertBodyContains("The page is missing!");
-  }
-
-  @Test
-  public void post_lotsOfMessagesFromKeys() throws Exception {
-    test.simulate(() -> simulator.test("/lots-of-messages")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContainsMessagesFromKeys(
-                                     "message1",
-                                     "message2",
-                                     "message3",
-                                     "message4",
-                                     "message5",
-                                     "message6",
-                                     "message7",
-                                     "message8",
-                                     "message9",
-                                     "message10"));
-
-    // Once for the API call and another for the message lookup
-    assertEquals(LotsOfMessagesAction.invocationCount.get(), 2);
-  }
-
-  @Test
-  public void post_multipart_parameter_mix() throws Exception {
-    // arrange
-    test.createFile("Hello World")
-        .simulate(() -> simulator.test("/user/full-form")
-                                 .withParameter("roleIds", 21)
-                                 .withParameter("roleIds", 22)
-                                 .withURLParameter("ages", 42)
-                                 .withParameter("stringField", "hello with space")
-                                 .withFile("image", test.tempFile, "text/plain")
-                                 .post()
-                                 // assert
-                                 .assertStatusCode(200));
-
-    assertEquals(FullFormAction.roleIdsFromLastPost.size(), 2);
-    assertEquals(FullFormAction.agesFromLastPost.size(), 1);
-    var fileContents = Files.readString((FullFormAction.imageFromLastPost.getFile()));
-    assertEquals(fileContents, "Hello World");
-    assertEquals(FullFormAction.stringFieldFromLastPost, "hello with space");
-  }
-
-  @Test
-  public void post_objectMapValues() throws Exception {
-    // Dot notation, set into typed map of Map<String, Object>
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.bar.baz", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-1-response.json")));
-
-    // Bracketed notation - functionally the same as dot. This should produce a map.
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.bar['baz']", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-2-response.json")));
-
-    // Bracketed notation - functionally the same as dot. This should produce a map.
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.bar['baz']", "bing")
-                                 .withParameter("foo.bar['baz']", "boom")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-3-response.json")));
-
-    // Bracketed notation using an integer, this is an array.
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.bar[0]", "bing")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-4-response.json")));
-
-    // Bracketed notation using an integer, this is an array.
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.bar[0]", "bing")
-                                 .withParameter("foo.bar[1]", "boom")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-5-response.json")));
-
-    // Nested properties
-    test.simulate(() -> simulator.test("/object-map-values")
-                                 .withParameter("foo.data.preferences.coffee.style", "with cream")
-                                 .withParameter("foo.data.preferences.cars.count", 2)
-                                 .withParameter("foo.data.preferences.fruit", "oranges")
-                                 .withParameter("foo.data.preferences.fruit", "apples")
-                                 .withParameter("foo.data.preferences.fruit", "strawberries")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-6-response.json")));
-  }
-
-  @Test
-  public void post_onlyAllowTextHTML() throws Exception {
-    test.createFile("<strong>Hello World</strong>")
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataTextHtml", test.tempFile, "text/plain")
-                                 .post()
-                                 .assertStatusCode(400))
-        .simulate(() -> simulator.test("/file-upload")
-                                 .withFile("dataTextHtml", test.tempFile, "text/html")
-                                 .post()
-                                 .assertStatusCode(200));
-  }
-
-  @Test
-  public void post_savedRequest_cookieExpired_orCannotBeDeserialized() throws Exception {
-    // Post to a page that requires authentication
-    BaseStoreAction.loggedIn = false;
-    test.simulate(() -> simulator.test("/store/purchase")
-                                 .withParameter("item", "beer")
-                                 .post()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/store/login")
-
-                                 // Redirected to login
-                                 .executeRedirect(
-                                     req -> req.assertStatusCode(200)
-                                               .assertHeaderContains("Cache-Control", "no-cache")
-                                               .assertBodyContains("Login")
-
-                                               // "expire" the flash cookie by rolling the encryption key
-                                               .setup(() -> configuration.regenerateCookieEncryptionKey())
-
-                                               // Post on Login, get a session, and redirect back to the cart which completes the beer purchase
-                                               .executeFormPostInResponseBody("form",
-                                                                              postReq -> postReq.assertStatusCode(302)
-                                                                                                .assertHeaderContains("Cache-Control", "no-cache")
-                                                                                                .assertRedirect("/store/")
-
-                                                                                                .executeRedirect(
-                                                                                                    redirReq -> redirReq.assertStatusCode(200)
-                                                                                                                        // We'll end up on the /store/index instead of completing the save request,
-                                                                                                                        // we're logged in, but the beer purchase failed. Sad.
-                                                                                                                        .assertBodyContains(
-                                                                                                                            "/store/index",
-                                                                                                                            "IsLoggedIn:true")
-                                                                                                                        .assertBodyDoesNotContain("Buy:beer")))));
-  }
-
-  @Test(dataProvider = "purchaseRoutes")
-  public void post_savedRequest_crossOrigin(String route) throws Exception {
-    // Post to a page that requires authentication
-    BaseStoreAction.loggedIn = false;
-
-    // A cross-origin POST request not work with saved request, so expect to just end up at the normal location after login
-    // allow-post-purchase has allowPost = true on the SaveRequest annotation but cross-origin should behave the same
-    test.simulate(() -> simulator.test(route)
-                                 .withParameter("item", "beer")
-                                 .withSingleHeader("Origin", "https://hacked.com")
-                                 .post()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/store/login")
-
-                                 // Redirected to login
-                                 .followRedirect(result -> result
-                                     .assertStatusCode(200)
-                                     .assertHeaderContains("Cache-Control", "no-cache")
-                                     .assertBodyContains("Login"))
-
-                                 // Post on Login, get a session, and redirect back to store index, because we threw out the saved request to the cart.
-                                 .submitForm("form", result -> result
-                                     .assertStatusCode(302)
-                                     .assertHeaderContains("Cache-Control", "no-cache")
-                                     .assertRedirect("/store/"))
-
-                                 .followRedirect(result -> result
-                                     .assertStatusCode(200)
-                                     .assertBody("""
-                                                     /store/index
-                                                     IsLoggedIn:true""")
-                                     .assertBodyDoesNotContain("Buy:beer")));
-  }
-
-  @Test
-  public void post_savedRequest_sameOriginAllowed() throws Exception {
-    // Post to a page that requires authentication
-    BaseStoreAction.loggedIn = false;
-
-    // Same origin POST request will work with saved request and allowPost =true
-    test.simulate(() -> simulator
-        .test("/store/allow-post-purchase")
-        .withParameter("item", "beer")
-        .post()
-        .assertStatusCode(302)
-        .assertHeaderContains("Cache-Control", "no-cache")
-        .assertRedirect("/store/login")
-
-        // Redirected to login
-        .followRedirect(result -> result
-            // assert the request that was made included the correct Referer header
-            // - We could make this configurable, but for now, it is sending the full header, simulating a Refer policy of same-origin.
-            //   See RequestResult._followRedirect notes.
-            .custom(() -> assertEquals(result.request.getHeader("Referer"),
-                                       "http://localhost:9080/store/allow-post-purchase"))
-            .assertStatusCode(200)
-            .assertHeaderContains("Cache-Control", "no-cache")
-            .assertBodyContains("Login"))
-
-        // Post on Login, get a session, and redirect back to the cart which completes the beer purchase
-        .submitForm("form", result -> result
-            .assertStatusCode(302)
-            .assertHeaderContains("Cache-Control", "no-cache")
-            .assertRedirect("/store/allow-post-purchase"))
-
-        .followRedirect(result -> result
-            .assertStatusCode(200)
-            .assertBody("""
-                            /store/purchase
-                            Buy:beer""")));
-  }
-
-  @Test
-  public void post_savedRequest_sameOriginDenied() throws Exception {
-    // Post to a page that requires authentication
-    BaseStoreAction.loggedIn = false;
-
-    // same origin post saved request will fail if allowPost = false
-    test.simulate(() -> simulator.test("/store/purchase")
-                                 .withParameter("item", "beer")
-                                 .post()
-                                 .assertStatusCode(302)
-                                 .assertHeaderContains("Cache-Control", "no-cache")
-                                 .assertRedirect("/store/login")
-
-                                 // Redirected to login
-                                 .followRedirect(result -> result
-                                     .assertStatusCode(200)
-                                     .assertHeaderContains("Cache-Control", "no-cache")
-                                     .assertBodyContains("Login"))
-
-                                 // Post on Login, get a session, and redirect back to store index, because we threw out the saved request to the cart.
-                                 .submitForm("form", result -> result
-                                     .assertStatusCode(302)
-                                     .assertHeaderContains("Cache-Control", "no-cache")
-                                     .assertRedirect("/store/"))
-
-                                 // land on the regular index page
-                                 .followRedirect(result -> result
-                                     .assertStatusCode(200)
-                                     .assertBody("""
-                                                     /store/index
-                                                     IsLoggedIn:true""")
-                                     .assertBodyDoesNotContain("Buy:beer")));
-  }
-
-  @Test
-  public void post_scopeStorage() throws Exception {
-    // Tests that the expression evaluator safely gets skipped while looking for values and Prime then checks the
-    // HttpServletRequest and finds the value
-    test.simulate(() -> simulator.test("/scope-storage")
-                                 .post())
-        .assertContextAttributeNotNull("contextObject");
-  }
-
-  @Test
-  public void post_scopeStorageInBaseClass() throws Exception {
-    // Set values during POST - fields exist in base abstract class
-    test.simulate(() -> simulator.test("/extended-scope-storage")
-                                 .post())
-        .assertContextAttributeNotNull("contextObject")
-
-        // Call [GET] -- assume everything is set from prior request except request attribute is null.
-        .simulate(() -> simulator.test("/extended-scope-storage")
-                                 .get())
-        .assertContextAttributeNotNull("contextObject")
-
-        // Call [GET] on a different action -- only action and context attributes come over, request and action session are null.
-        .simulate(() -> simulator.test("/another-extended-scope-storage")
-                                 .get())
-        .assertContextAttributeNotNull("contextObject");
-  }
-
-  @Test
-  public void post_unsupported_multipleParameters() throws Exception {
-    // Cannot jam an array into a non-array data type
-
-    // UUID, two values, no dice.
-    // - We will get a 200, watch the console for the log output.
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withParameter("uuidValue", UUID.randomUUID())
-                                 .withParameter("uuidValue", UUID.randomUUID())
-                                 .post()
-                                 .assertStatusCode(500)
-                                 .assertBodyIsEmpty());
-
-    TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
-        "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type UUID. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [uuidValue]"));
-
-    // Enum, two values, no dice
-    // - We will get a 200, watch the console for the log output.
-    test.simulate(() -> simulator.test("/parameter-handler")
-                                 .withParameter("enumValue", ParameterHandlerAction.Fruit.Orange)
-                                 .withParameter("enumValue", ParameterHandlerAction.Fruit.Apple)
-                                 .post()
-                                 .assertStatusCode(500)
-                                 .assertBodyIsEmpty());
-
-    TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
-        "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type Enum. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [enumValue]"));
-  }
-
-  @Test
-  public void post_withURLParameter_IndexAmbiguity() {
-    // https://github.com/FusionAuth/fusionauth-issues/issues/434
-
-    // Add a trailing slash when the URL parameter is {userId} which is a UUID
-    // - Ok, it is ignored and there are no conversion exceptions
-    simulator.test("/api/action-value/login/")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
-
-    // Manually added the 'index' suffix, expect a couldNotConvert error because this is not a UUID
-    simulator.test("/api/action-value/login/index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsFieldErrors("userId")
-             .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
-
-    // Leave a trailing slash and pass an invalid type for userId as a request parameter
-    simulator.test("/api/action-value/login/")
-             .withParameter("userId", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsFieldErrors("userId")
-             .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
-
-    // No trailing slash and pass an invalid type for userId as a request parameter
-    simulator.test("/api/action-value/login")
-             .withParameter("userId", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsFieldErrors("userId")
-             .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
-
-    // Leave a trailing slash and use a separate variable with the name 'index'
-    simulator.test("/api/action-value/login/")
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/login", "potato:index", "userId:null");
-
-    // Correct usage, URL parameter with the correct type.
-    UUID userId = UUID.randomUUID();
-    simulator.test("/api/action-value/login")
-             .withURLSegment(userId)
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/login", "potato:index", "userId:" + userId);
-
-    // With a real Index page, add a URL parameter, add a separate request parameter with a value of index
-    simulator.test("/api/action-value/index")
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/index", "potato:index", "userId:null");
-
-    // Real Index page, add a trailing slash when the URL parameter is a UUID
-    // - The trailing slash should be ignored, no errors
-    simulator.test("/api/action-value/index/")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/index", "potato:null", "userId:null");
-
-    // Real Index page, with a legit UUID on the URL
-    simulator.test("/api/action-value/index/" + userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
-
-    // Real Index page, with a legit UUID using a URL segment and a trailing slash
-    simulator.test("/api/action-value/index/")
-             .withURLSegment(userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
-
-    // Real Index page, with a legit UUID using a URL segment and no trailing slash
-    simulator.test("/api/action-value/index")
-             .withURLSegment(userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
-  }
-
-  @Test
-  public void post_withoutURLParameter_IndexAmbiguity() {
-    // https://github.com/FusionAuth/fusionauth-issues/issues/434
-
-    // Add a trailing slash when the URL parameter is {userId} which is a UUID
-    // - Ok, it is ignored and there are no conversion exceptions
-    simulator.test("/api/no-action-value/login/")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
-
-    // All of these will be ignored
-    simulator.test("/api/no-action-value/login/foo/bar/baz")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
-
-    // Manually added the 'index' suffix, not expect a URL segment, so it is ignored.
-    simulator.test("/api/no-action-value/login/index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
-
-    // Leave a trailing slash and pass an invalid type for userId as a request parameter
-    simulator.test("/api/no-action-value/login/")
-             .withParameter("userId", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsFieldErrors("userId")
-             .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
-
-    // No trailing slash and pass an invalid type for userId as a request parameter
-    simulator.test("/api/no-action-value/login")
-             .withParameter("userId", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsFieldErrors("userId")
-             .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
-
-    // Leave a trailing slash and use a separate variable with the name 'index'
-    simulator.test("/api/no-action-value/login/")
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:null");
-
-    // URL parameter is ignored since the Action is not configured to take a URL parameter
-    UUID userId = UUID.randomUUID();
-    simulator.test("/api/no-action-value/login")
-             .withURLSegment(userId)
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:null");
-
-    // userId and potato are taking as request parameters, bonzai!
-    simulator.test("/api/no-action-value/login")
-             .withURLSegment(userId)
-             .withParameter("potato", "index")
-             .withParameter("userId", userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:" + userId);
-
-    // With a real Index page, add a URL parameter, add a separate request parameter with a value of index
-    simulator.test("/api/no-action-value/index")
-             .withParameter("potato", "index")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/index", "potato:index", "userId:null");
-
-    // Real Index page, add a trailing slash when the URL parameter is a UUID
-    // - The trailing slash should be ignored, no errors
-    simulator.test("/api/no-action-value/index/")
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
-
-    // Real Index page, with a legit UUID on the URL but it is ignored because are not capturing URL parameters
-    simulator.test("/api/no-action-value/index/" + userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
-
-    // Real Index page, with a legit UUID using a URL segment and a trailing slash, ignored.
-    simulator.test("/api/no-action-value/index/")
-             .withURLSegment(userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
-
-    // Real Index page, with a legit UUID using a URL segment and no trailing slash, ignored
-    simulator.test("/api/no-action-value/index")
-             .withURLSegment(userId)
-             .post()
-             .assertStatusCode(200)
-             .assertContainsNoFieldMessages()
-             .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
-  }
-
-  @DataProvider
-  public Object[][] purchaseRoutes() {
-    return new Object[][]{
-        {"/store/purchase"},
-        {"/store/allow-post-purchase"}
-    };
-  }
-
-  @Test
-  public void singletons() {
-    assertSingleton(ActionConfigurationProvider.class);
-    assertSingleton(Configuration.class);
-    assertSingleton(ResourceBundle.Control.class);
-    assertSingleton(ResourceBundle.Control.class);
-    assertSingleton(ContainerResolver.class);
-    assertSingleton(ConverterProvider.class);
-    assertSingleton(ExpressionEvaluator.class);
-    assertSingleton(URIBuilder.class);
-    assertSingletonConverter(Boolean.class);
-    assertSingletonConverter(boolean.class);
-    assertSingletonConverter(Character.class);
-    assertSingletonConverter(char.class);
-    assertSingletonConverter(Number.class);
-    assertSingletonConverter(int.class);
-    assertSingletonConverter(long.class);
-    assertSingletonConverter(double.class);
-    assertSingletonConverter(float.class);
-    assertSingletonConverter(BigDecimal.class);
-    assertSingletonConverter(BigInteger.class);
-    assertSingletonConverter(Collection.class);
-    assertSingletonConverter(ZonedDateTime.class);
-    assertSingletonConverter(Enum.class);
-    assertSingletonConverter(File.class);
-    assertSingletonConverter(LocalDate.class);
-    assertSingletonConverter(Locale.class);
-    assertSingletonConverter(String.class);
-  }
-
-  @Test
-  public void uriParameters() throws Exception {
-    test.simulate(() -> simulator.test("/complex-rest/brian/static/pontarelli/then/a/bunch/of/stuff")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBodyContains("firstName=brian", "lastName=pontarelli", "theRest=then,a,bunch,of,stuff"));
-  }
-
-  private void assertSingleton(Class<?> type) {
-    assertSame(injector.getInstance(type), injector.getInstance(type));
-  }
-
-  private void assertSingletonConverter(Class<?> type) {
-    // Adding a noinspection, there is a bug in the JDK that is exposed when you take the suggestion of IJ and replace this TypeLiteral type info with <>
-    // Ask me how I know... see https://stackoverflow.com/questions/50885335/java-10-compilaton-null-pointer-exception
-    //noinspection Convert2Diamond
-    Map<Class<?>, GlobalConverter> converters = injector.getInstance(Key.get(new TypeLiteral<Map<Class<?>, GlobalConverter>>() {
-    }));
-    assertSame(converters.get(type), converters.get(type));
-  }
-
-  private byte[] readBytes(String path) {
-    try {
-      return Files.readAllBytes(Path.of(path));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+    @Test
+    public void get_unknownParameters() throws Exception {
+        configuration.allowUnknownParameters = false;
+        test.simulate(() -> simulator.test("/unknown-parameters")
+                .withParameter("foo", "bar")
+                .withParameter("foo", "baz")
+                .withParameter("foo.bar", "baz")
+                .withParameter("foo/0/bar/bam", "purple")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains(
+                        "foo => [bar,baz]",
+                        "foo.bar => [baz]",
+                        "foo/0/bar/bam => [purple]"
+                ));
     }
-  }
+
+    @Test
+    public void get_url_rewrite() {
+        // Ensure a legacy configuration no longer has any affect on the request mapper.
+        simulator.test("/doesNotExist?__a_foo=/user/edit&foo=true")
+                .get()
+                .assertStatusCode(404)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("The page is missing!");
+        assertFalse(EditAction.getCalled);
+    }
+
+    @Test
+    public void get_wellKnownDotPrefixed() throws Exception {
+        test.simulate(() -> simulator.test("/.well-known/openid-configuration")
+                .get()
+                .assertStatusCode(200)
+                .assertJSON("{\"called\": \"/.well-known/openid-configuration\"}"));
+
+        // The nested directory does not have a package-modifier, so we will get the actual path of 'well-known' instead of '.well-known'.
+        test.simulate(() -> simulator.test("/.well-known/well-known/openid-configuration")
+                .get()
+                .assertStatusCode(200)
+                .assertJSON("{\"called\": \"/.well-known/well-known/openid-configuration\"}"));
+
+        // Testing two levels deep, but only the 1st and 3rd level have a package modifier.
+        // .well-known -> well-known -> .well-known. The package modifier causes us to ignore the 'potato' package name.
+        test.simulate(() -> simulator.test("/.well-known/well-known/.well-known/openid-configuration")
+                .get()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSON("{\"called\": \"/.well-known/well-known/potato/openid-configuration\"}"));
+
+        // This is an invalid mapping, so it will result in a 404
+        test.simulate(() -> simulator.test("/.well-known/.well-known/openid-configuration")
+                .get()
+                .assertStatusCode(404));
+    }
+
+    @Test
+    public void hacked() {
+        // Make sure we don't invoke "freemarker.template.utility.Execute"
+        simulator.test("/hacked")
+                .get()
+                .assertStatusCode(500)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Instantiating freemarker.template.utility.Execute is not allowed in the template for security reasons.");
+    }
+
+    @Test
+    public void headers() throws IOException {
+        // Make sure multiple headers with the same name get returned
+        simulator.test("/header-values")
+                .withHeader("foo", "bar")
+                .withHeader("foo", "baz")
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/foo", List.of("bar", "baz"));
+    }
+
+    @Test
+    public void headers_withHeaderIfPresent() throws IOException {
+        // Null value should not add the header
+        simulator.test("/header-values")
+                .withHeaderIfPresent("foo", null)
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/foo", null);
+
+        // Non-null value should add the header
+        simulator.test("/header-values")
+                .withHeaderIfPresent("foo", "bar")
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/foo", List.of("bar"));
+    }
+
+    @Test
+    public void dpopHeader() throws IOException {
+        // Make sure DPoPProofProvider gets invoked with proper values
+        // (a real DPoPProofProvider would generate a signed JWT)
+        DPoPProofProvider provider = (httpMethod, htu, accessToken) -> httpMethod.toString() + ":" + htu + ":" + accessToken;
+
+        simulator.test("/header-values")
+                .withDPoPProofProvider(provider)
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/dpop", List.of("GET:http://localhost:9080/header-values:null"));
+
+        simulator.test("/header-values")
+                .withDPoPProofProvider(provider)
+                .withAuthorizationDPoPToken("fake.token")
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/authorization", List.of("DPoP fake.token"))
+                .assertJSONValuesAt("/dpop", List.of("GET:http://localhost:9080/header-values:fake.token"));
+
+        simulator.test("/header-values")
+                .withDPoPProofProvider(provider)
+                .post()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/dpop", List.of("POST:http://localhost:9080/header-values:null"));
+
+        simulator.test("/header-values")
+                .withDPoPProofProvider(provider)
+                .withAuthorizationDPoPToken("fake.token")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/authorization", List.of("DPoP fake.token"))
+                .assertJSONValuesAt("/dpop", List.of("POST:http://localhost:9080/header-values:fake.token"));
+    }
+
+    @Test
+    public void bearerTokenAuthHeader() throws IOException {
+        // Exercise the withAuthorizationBearerToken() call
+
+        simulator.test("/header-values")
+                .withAuthorizationBearerToken("fake.token")
+                .get()
+                .assertStatusCode(200)
+                .assertJSONValuesAt("/authorization", List.of("Bearer fake.token"));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void bearerTokenAndDPoPTokenAuthHeader() throws IOException {
+        // Ensure we can't call withAuthorizationBearerToken() and withAuthorizationDPoPToken()
+
+        simulator.test("/header-values")
+                .withAuthorizationBearerToken("fake.bearer.token")
+                .withAuthorizationDPoPToken("fake.dpop.token");
+    }
+
+    @Test
+    public void head() {
+        simulator.test("/head")
+                .head()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyIsEmpty();
+    }
+
+    @Test
+    public void head_jwtAuthorized() throws Exception {
+        // This test will pass if we call the JWT authorize method or not....
+        JwtAuthorizedAction.authorized = true;
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .head()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void head_jwtNotAuthorized() throws Exception {
+        JwtAuthorizedAction.authorized = false;
+        test.simulate(() -> simulator.test("/jwt-authorized")
+                .withHeader("Authorization", "JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkifQ.qHdut1UR4-2FSAvh7U3YdeRR5r5boVqjIGQ16Ztp894")
+                .head()
+                .assertStatusCode(401)
+                .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test(enabled = false)
+    public void manual_tooManyOpenFiles() throws Exception {
+        // Cause a connection reset to the HTTP server, and only close every 100th connection.
+        // - This will cause the connection reset and eventually also cause a 'Too many open files' exception.
+        for (int i = 0; i < 250_000; i++) {
+            if (i % 5_000 == 0) {
+                System.out.println("Iteration [" + i + "]....");
+            }
+
+            try {
+                Socket socket = new Socket();
+                socket.setSoLinger(true, 0);
+                socket.connect(new InetSocketAddress("localhost", 8080));
+                OutputStream os = socket.getOutputStream();
+                // Build an HTTP request body
+                os.write((
+                        "POST /inform HTTP/1.1\r\n" +
+                                "Host: 192.168.1.44:8080\r\n" +
+                                "Accept: */*\r\n" +
+                                "Content-Length: 8588\r\n" +
+                                "\r\n"
+                ).getBytes(StandardCharsets.UTF_8));
+
+                os.flush();
+                if (i % 100 == 0) {
+                    socket.close();
+                }
+
+            } catch (Exception e) {
+                System.out.println("[Test Exception] [" + e.getMessage() + "]");
+            }
+        }
+
+        boolean finish = false;
+        while (!finish) {
+            System.out.println("Waiting.... kill the test, or pause the debugger and set finish = true.");
+            Thread.sleep(10_000);
+        }
+    }
+
+    @Test
+    public void missing() {
+        // Direct action invocation
+        simulator.test("/missing")
+                .get()
+                .assertStatusCode(404)
+                .assertBodyContains("The page is missing!");
+
+        // A traditional 404
+        simulator.test("/also-missing")
+                .get()
+                .assertStatusCode(404)
+                .assertBodyContains("The page is missing!");
+    }
+
+    @Test
+    public void multipleJSONRequestMembers() throws Exception {
+        simulator.test("/multiple-json-request")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache");
+
+        simulator.test("/multiple-json-request")
+                .withJSON(new Object())
+                .post()
+                .assertStatusCode(201)
+                .assertHeaderContains("Cache-Control", "no-cache");
+
+        simulator.test("/multiple-json-request")
+                .withJSON(new Object())
+                .delete()
+                .assertStatusCode(202)
+                .assertHeaderContains("Cache-Control", "no-cache");
+    }
+
+    @Test
+    public void notAllowed() {
+        simulator.test("/not-allowed")
+                .get()
+                .assertStatusCode(405)
+                .assertHeaderContains("Cache-Control", "no-cache");
+
+        simulator.test("/not-allowed")
+                .post()
+                .assertStatusCode(405);
+
+        simulator.test("/not-allowed")
+                .put()
+                .assertStatusCode(405);
+
+        simulator.test("/not-allowed")
+                .delete()
+                .assertStatusCode(405);
+
+        // head is allowed
+        simulator.test("/not-allowed")
+                .head()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache");
+    }
+
+    @Test
+    public void notImplemented() {
+        simulator.test("/not-allowed")
+                .method("POTATO")
+                // We currently only map out execute methods in the action that are named by a method
+                // defined in the HTTPMethod.StandardMethods. If an action does not define a standard HTTP
+                // method, a 405 will be returned. If you ask for a non-standard method that is not implemented
+                // by prime-mvc, you will receive a 501.
+                .assertStatusCode(501)
+                .assertHeaderContains("Cache-Control", "no-cache");
+    }
+
+    @Test
+    public void parameter_order_of_operation() throws Exception {
+        // Test the order of operation when we have parameters in a body, URI segment, and query string.
+
+        // Provide segment, body and parameter, additive - parameter + body
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLSegment("segment")
+                .withURLParameter("value", "parameter")
+                .withContentType("application/x-www-form-urlencoded")
+                .withBody("""
+                        value=body
+                        """)
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:parameter,body"));
+
+        // Segment and parameter, parameter wins
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLSegment("segment")
+                .withURLParameter("value", "parameter")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:parameter"));
+
+        // Segment and body, body wins
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLSegment("segment")
+                .withContentType("application/x-www-form-urlencoded")
+                .withBody("""
+                        value=body
+                        """)
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:body"));
+
+        // Parameter and body, additive - parameter + body
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLParameter("value", "parameter")
+                .withContentType("application/x-www-form-urlencoded")
+                .withBody("""
+                        value=body
+                        """)
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:parameter,body"));
+
+        // Body only, body
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withContentType("application/x-www-form-urlencoded")
+                .withBody("""
+                        value=body
+                        """)
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:body"));
+
+        // Segment only, segment
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLSegment("segment")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:segment"));
+
+        // Parameter only, parameter
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withURLParameter("value", "parameter")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("value:parameter"));
+    }
+
+    @Test
+    public void post() {
+        simulator.test("/post")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertBodyContains("Brian Pontarelli", "35", "Broomfield", "CO");
+    }
+
+    @Test
+    public void post_JSONWithActual() throws Exception {
+        simulator.test("/api")
+                .withJSONFile(Path.of("src/test/resources/json/api-jsonWithActual-post.json"))
+                .post()
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertJSONFileWithActual(UserField.class, Path.of("src/test/resources/json/api-jsonWithActual-post-response.ftl"));
+
+        // Test a final field (the Jackson handler will put the JSON into the final field)
+        simulator.test("/api-final")
+                .withJSONFile(Path.of("src/test/resources/json/api-jsonWithActual-post.json"))
+                .post()
+                .assertJSONFileWithActual(UserField.class, Path.of("src/test/resources/json/api-jsonWithActual-post-response.ftl"));
+    }
+
+    @Test
+    public void post_anyContentType() throws Exception {
+        test.createFile("Hello World")
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataAnyType", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache"))
+
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataAnyType", test.tempFile, "text/html")
+                        .post()
+                        .assertStatusCode(200))
+
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataAnyType", test.tempFile, "application/octet-stream")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test
+    public void post_apiJSONBothWays() throws Exception {
+        Path jsonFile = Path.of("src/test/resources/json/api-jsonBothWays-post.json");
+        simulator.test("/api")
+                .withJSONFile(jsonFile)
+                .post()
+                .assertJSONFile(jsonFile);
+    }
+
+    @Test
+    public void post_binary() throws Exception {
+        test.simulate(() -> simulator.test("/binary")
+                .withURLParameter("expected", "Hello World")
+                .withBody("Hello World")
+                .withContentType("application/octet-stream")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test
+    public void post_binary_no_body() throws Exception {
+        test.simulate(() -> simulator.test("/binary")
+                .withURLParameter("expectedNullFile", "true")
+                .withContentType("application/octet-stream")
+                .post()
+                .assertStatusCode(200)
+                .assertHeaderContains("Cache-Control", "no-cache"));
+    }
+
+    @Test
+    public void post_chunked_json() throws Exception {
+        // Our simulator does not chunk. This test uses the Java HTTP client to test chunking with Content-Type: application/json
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.of(500, ChronoUnit.MILLIS))
+                .build();
+
+        var response = client.send(
+                HttpRequest.newBuilder()
+                        .uri(URI.create("http://localhost:9080/api"))
+                        .header(Headers.ContentType, "application/json")
+                        .POST(BodyPublishers.ofInputStream(() -> new ByteArrayInputStream(readBytes("src/test/resources/json/api-jsonWithActual-post.json"))))
+                        .build(),
+                r -> BodySubscribers.ofString(StandardCharsets.UTF_8)
+        );
+
+        assertEquals(response.statusCode(), 200);
+    }
+
+    @Test
+    public void post_collectionConverter() throws Exception {
+        // Single string containing commas, output contains the same string
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withParameter("strings", "foo,bar,baz")
+                .post()
+                .assertStatusCode(200));
+
+        // Multiple values, output contains these two values in a collection
+        test.simulate(() -> simulator.test("/collection-converter")
+                .withParameter("strings", "bar")
+                .withParameter("strings", "baz")
+                .post()
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void post_cookies() throws Exception {
+        // Test cookie propagation between invocations within the same test
+        test.simulate(() -> simulator.test("/cookie")
+                        .withParameter("name", "token")
+                        .withParameter("value", "secret")
+                        .withParameter("saveMe", "save a value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty()
+                        // Assert the cookie is set
+                        .assertCookie("token", "secret")
+                        // Assert we dropped a cookie for the @BrowserActionSession
+                        .assertContainsCookie("org.example.action.CookieAction$saveMe"))
+
+                // Now make a GET request to the same action and verify the cookies were picked up on the request.
+                .simulate(() -> simulator.test("/cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains(
+                                "Count:2",
+                                "token:secret",
+                                "org.example.action.CookieAction$saveMe:") // the value will be encoded
+                        // Cookie is not written back on this response
+                        .assertDoesNotContainsCookie("token"))
+
+                // Clear the value set by @CookieAction by asking the action to set the value to 'null'
+                .simulate(() -> simulator.test("/cookie")
+                        .withParameter("clearSaveMe", true)
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty()
+                        // Cookie is written out with a null
+                        .assertContainsCookie("org.example.action.CookieAction$saveMe"))
+
+                // Retrieve again, value will be gone.
+                .simulate(() -> simulator.test("/cookie")
+                        .get()
+                        .assertBodyContains(
+                                "Count:1",
+                                "token:secret")
+                        .assertBodyDoesNotContain(
+                                "org.example.action.CookieAction$saveMe:") // the value will be encoded
+                        // Cookie is not written back on this response
+                        .assertDoesNotContainsCookie("org.example.action.CookieAction$saveMe"))
+
+                // Set a generic type
+                .simulate(() -> simulator.test("/cookie")
+                        .withParameter("u.bar", "baz")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty()
+                        // Assert we dropped a cookie for the @BrowserActionSession
+                        .assertContainsCookie("org.example.action.CookieAction$u"))
+
+                // Call get and see the value is set back into the action
+                .simulate(() -> simulator.test("/cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains(
+                                "Count:2",
+                                "token:secret",
+                                "org.example.action.CookieAction$u:") // the value will be encoded
+                        // Cookie is not written back on this response
+                        .assertDoesNotContainsCookie("token"))
+
+                // Set a generic collection
+                .simulate(() -> simulator.test("/cookie")
+                        .withParameter("list[0]bar", "bing")
+                        .withParameter("list[1]bar", "boom")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyIsEmpty()
+                        // Assert we dropped a cookie for the @BrowserActionSession
+                        .assertContainsCookie("org.example.action.CookieAction$list"))
+
+                .simulate(() -> simulator.test("/cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBodyContains(
+                                "Count:3",
+                                "token:secret",
+                                "org.example.action.CookieAction$list:", // the value will be encoded
+                                "org.example.action.CookieAction$u:") // the value will be encoded
+                        // Cookie is not written back on this response
+                        .assertDoesNotContainsCookie("token"))
+
+                // Blow chunks and get an error in the message store that will use the cookie lash message scope.
+                .simulate(() -> simulator.test("/cookie")
+                        .withURLParameter("blowChunks", true)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertContainsGeneralErrorMessageCodes("[CookieErrorException]")
+                        .assertBodyContainsMessagesFromKey("[CookieErrorException]")
+                        .assertBodyContains("Error count:1"))
+
+                // Add a message to the message store on a post / redirect and ensure we only end up with a single message in the store.
+                .simulate(() -> simulator.test("/cookie")
+                        .withURLParameter("addMessage", true)
+                        .post()
+                        .assertStatusCode(302)
+                        .assertRedirect("/cookie")
+                        .assertContainsGeneralInfoMessageCodes("[NobodyDrinkTheBeer]")
+
+                        // Execute the redirect and ensure we don't have duplicate messages
+                        .executeRedirect(result -> result.assertStatusCode(200)
+                                .assertBodyContains(
+                                        "Count:3",
+                                        "token:secret",
+                                        "org.example.action.CookieAction$list:", // the value will be encoded
+                                        "org.example.action.CookieAction$u:") // the value will be encoded
+                                .assertContainsGeneralInfoMessageCodes("[NobodyDrinkTheBeer]")));
+    }
+
+    @Test
+    public void post_couldNotConvert() throws Exception {
+        // Could not convert, no specific message for key
+        test.simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap1['foo']", "bar")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap1['foo']")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[]"))
+
+                // Could not convert, specific message for this key
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap1['bar']", "baz")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap1['bar']")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1['bar']"))
+
+                // Could not convert, using generic message from Prime
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap2['baz']", "bing")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap2['baz']")
+                        .assertBodyContains("Value Baz (java.lang.NumberFormatException: For input string: &quot;bing&quot;"))
+
+                // Unquoted versions
+
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap1[foo2]", "bar")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap1[foo2]")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[]"))
+
+                // Could not convert, specific message for this key
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap1[bar2]", "baz")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap1[bar2]")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerMap1[bar2]"))
+
+                // Could not convert, using generic message from Prime
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerMap2[baz2]", "bing")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerMap2[baz2]")
+                        .assertBodyContains("Value Baz (java.lang.NumberFormatException: For input string: &quot;bing&quot;"))
+
+                // Numeric
+
+                // Could not convert, no specific message for this index in a list
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerList1[0]", "bar")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerList1[0]")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerList1[]"))
+
+                // Could not convert, specific message for this index in a list
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerList1[1]", "baz")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerList1[1]")
+                        .assertBodyContainsMessagesFromKeys("[couldNotConvert]integerList1[1]"))
+
+                // Could not convert, using generic message from Prime for the list
+                .simulate(() -> simulator.test("/could-not-convert")
+                        .withParameter("integerList2[0]", "bing")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertContainsFieldErrors("integerList2[0]")
+                        .assertBodyContains("List 2 - Int 1 (java.lang.NumberFormatException: For input string: &quot;bing&quot;"));
+    }
+
+    @Test
+    public void post_dateConversion() throws Exception {
+        // Multiple LocalDate formats
+        test.forEach(
+                        "01-01-2018",
+                        "01-01-2018",
+                        "1-1-2018",
+                        "1/01/2018",
+                        "01/1/2018")
+                .test(date -> simulator.test("/date-time-converter")
+                        .withParameter("localDate", date)
+                        .withParameter("localDate@dateTimeFormat", "[MM/dd/yyyy][M/dd/yyyy][M/d/yyyy][MM-dd-yyyy][M-dd-yyyy][M-d-yyyy]")
+                        .post()
+                        .assertContainsNoFieldMessages()
+                        .assertStatusCode(200));
+
+        // Single LocalDate format
+        test.simulate(() -> simulator.test("/date-time-converter")
+                .withParameter("localDate", "01/01/2018")
+                .withParameter("localDate@dateTimeFormat", "MM/dd/yyyy")
+                .post()
+                .assertContainsNoFieldMessages()
+                .assertStatusCode(200));
+
+        // Multiple ZonedDateTime formats
+        test.forEach(
+                        "07-08-2008 10:13:34 AM -0800",
+                        "07/08/2008 10:13:34 AM -0800",
+                        "7-8-2008 10:13:34 AM -0800",
+                        "7/8/2008 10:13:34 AM -0800")
+                .test(zoneDateTime -> simulator.test("/date-time-converter")
+                        .withParameter("zonedDateTime", zoneDateTime)
+                        .withParameter("zonedDateTime@dateTimeFormat", "[MM-dd-yyyy hh:mm:ss a Z][MM/dd/yyyy hh:mm:ss a Z][M/d/yyyy hh:mm:ss a Z][M-d-yyyy hh:mm:ss a Z]")
+                        .post()
+                        .assertContainsNoFieldMessages()
+                        .assertStatusCode(200));
+
+        // Single ZonedDateTime format
+        test.simulate(() -> simulator.test("/date-time-converter")
+                .withParameter("zonedDateTime", "07-08-2008 10:13:34 AM -0800")
+                .withParameter("zonedDateTime@dateTimeFormat", "MM-dd-yyyy hh:mm:ss a Z")
+                .post()
+                .assertContainsNoFieldMessages()
+                .assertStatusCode(200));
+    }
+
+    @Test
+    public void post_fieldNames() {
+        // Allow for unknown-parameters so that we can test runtime stuff.
+        configuration.allowUnknownParameters = true;
+
+        // Use annotation on a field and method
+        simulator.test("/field-name")
+                .withParameter("x-field", "value-field-a")
+                .withParameter("x-method", "value-method-a")
+                .withParameter("secondField", "value-field-b")
+                .withParameter("methodB", "value-method-b")
+                .withParameter("setfoo", "value-method-setfoo")
+                .withParameter("setBar", "value-method-setBar")
+                .withParameter("getBaz", "value-method-getBaz")
+                .withParameter("getboom", "value-method-getboom")
+                .withParameter("privateField", "value-private-field")
+                .withParameter("getValue", "value-method-getValue")
+                .withParameter("value2", "value-method-value2")
+                .withParameter("fieldA", "value-field-a-2")
+                .withParameter("fieldB", "value-field-b-2")
+                .post()
+                .assertStatusCode(200)
+                .assertBody("""
+                        fieldA:null
+                        fieldB:null
+                        fieldB:value-field-b
+                        methodA:value-method-a
+                        methodB:value-method-b
+                        methodC:null
+                        methodC:null
+                        foobar:null
+                        somethingElse1:value-method-setfoo
+                        somethingElse2:value-method-setBar
+                        somethingElse3:value-method-getBaz
+                        somethingElse4:value-method-getboom
+                        methodE:value-method-getBaz
+                        methodF:value-method-getboom
+                        methodG:value-method-getValue
+                        methodH:value-method-value2
+                        """);
+    }
+
+    @Test
+    public void post_fileUploadDisabled() throws Exception {
+        // File uploads are disabled by default, and unless the action annotates @FileUpload we should reject the request.
+        test.createFile("Hello World")
+                .simulate(() -> simulator.test("/no-files")
+                        .withFile("dataAnyType", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(422))
+
+                // This action does not have an explicit mapping configured, but it should default.
+                .createFile("Hello World")
+                .simulate(() -> simulator.test("/no-files-no-result-mapping")
+                        .withFile("dataAnyType", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(422));
+    }
+
+    @Test
+    public void post_file_tooLarge() throws Exception {
+        // File uploads are disabled by default, and unless the action annotates @FileUpload we should reject the request.
+        test.createFile("X".repeat(1024 * 1024 * 2))
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataAnyType", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(413));
+    }
+
+    // Test that the control behaves as expected
+    @Test
+    public void post_freemarker_escape() throws Exception {
+        simulator.test("/freemarker/escape")
+                .withParameter("listTest", "none")
+                .withParameter("listTest2", "none")
+                .post()
+                .assertStatusCode(200)
+                .assertHTML(html -> html.assertElementExists("input[name=listTest][value=none][checked]")
+                        .assertElementExists("input[name=listTest2][value=none][checked]"));
+    }
+
+    @Test
+    public void post_fuzzing_invalid_expression() throws Exception {
+        // simulate a production runtime
+        configuration.allowUnknownParameters = true;
+        test.simulate(() -> simulator.test("/vanilla")
+                // This is an invalid expression, but unknown parameters are ignored.
+                .withParameter("class.method", "foo")
+                .post()
+                .assertStatusCode(200));
+
+        // simulate dev runtime
+        configuration.allowUnknownParameters = false;
+        test.simulate(() -> simulator.test("/vanilla")
+                // This is an invalid expression, an exception will be thrown and return a 500.
+                .withParameter("class.method", "foo")
+                .post()
+                .assertStatusCode(500));
+    }
+
+    @Test
+    public void post_generics() throws Exception {
+        test.simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "one")
+                        .withParameter("typedObject.mapOfTypes[49e0f299-a2b0-4439-b0d5-3e2cc8949675].one", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Map one = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.mapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Map two = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.fullyGenericMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Map key/value = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.listOfStrings[0]", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("List string = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.listOfTypes[0].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("List two = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.singleString", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Single string = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.singleType.two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Single two = value"))
+
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "one")
+                        .withParameter("typedObject.privateMapOfTypes[49e0f299-a2b0-4439-b0d5-3e2cc8949675].one", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private Map one = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private Map two = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateFullyGenericMapOfTypes[eee47c8b-4134-4c4d-ab28-cacaeed84cdb].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private Map key/value = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateListOfStrings[0]", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private List string = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateListOfTypes[0].two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private List two = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateSingleString", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private Single string = value"))
+                .simulate(() -> simulator.test("/generics")
+                        .withParameter("type", "two")
+                        .withParameter("typedObject.privateSingleType.two", "value")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBodyContains("Private Single two = value"));
+    }
+
+    @Test
+    public void post_invalidJSON() throws Exception {
+        test.simulate(() -> simulator.test("/invalid-json")
+                .withJSONFile(Path.of("src/test/resources/json/InvalidJsonAction.json"))
+                .post()
+                .assertStatusCode(400)
+                .assertContainsFieldErrors("active")
+                // The actual exception seems to vary a bit, so instead we are asserting the content type and then that some specific info is in the body.
+                .assertContentType("application/json; charset=UTF-8")
+                .assertBodyContains(
+                        "[invalidJSON]",
+                        "Unable to parse JSON. The property [active] was invalid. The error was [Possible conversion error]. The detailed exception was ["));
+    }
+
+    @Test
+    public void post_jsonContentType() throws Exception {
+        // Content-Type: application/scim+json
+        simulator.test("/json-content-type")
+                .withContentType("application/test+json")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(400)
+                .assertJSON("""
+                        {
+                          "fieldErrors" : { },
+                          "generalErrors" : [ {
+                            "code" : "[InvalidContentType]",
+                            "message" : "Invalid [Content-Type] HTTP request header value of [application/test+json]. Supported values for this request include [application/json]."
+                          } ]
+                        }
+                        """);
+
+        // Patch not supported on this endpoint
+        simulator.test("/json-content-type-no-restriction")
+                .withContentType("application/json-patch+json")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(400)
+                .assertJSON("""
+                        {
+                          "fieldErrors" : { },
+                          "generalErrors" : [ {
+                            "code" : "[PatchNotSupported]",
+                            "message" : "The [Content-Type] HTTP request header value of [application/json-patch+json] is not supported for this request."
+                          } ]
+                        }
+                        """);
+
+        // Missing Content-Type Header
+        simulator.test("/json-content-type")
+                .withContentType("")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(400)
+                .assertJSON("""
+                         {
+                           "fieldErrors" : { },
+                           "generalErrors" : [ {
+                             "code" : "[MissingContentType]",
+                             "message" : "Missing required [Content-Type] HTTP request header."
+                           } ]
+                         }
+                        """);
+
+        // Supported Content-Type, but invalid for this request, however, because a body is provided, it will be allowed.
+        simulator.test("/json-content-type")
+                .withContentType("application/x-www-form-urlencoded")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyIsEmpty();
+
+        // Not supported in general, but this action has restrictions, so we'll get a validation error.
+        simulator.test("/json-content-type")
+                .withContentType("application/klingon")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(400)
+                .assertJSON("""
+                        {
+                          "fieldErrors" : { },
+                          "generalErrors" : [ {
+                            "code" : "[InvalidContentType]",
+                            "message" : "Invalid [Content-Type] HTTP request header value of [application/klingon]. Supported values for this request include [application/json]."
+                          } ]
+                        }
+                        """);
+
+        // Not supported in general
+        simulator.test("/json-content-type-no-restriction")
+                .withContentType("application/klingon")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(400)
+                .assertJSON("""
+                         {
+                           "fieldErrors" : { },
+                           "generalErrors" : [ {
+                             "code" : "[UnsupportedContentType]",
+                                 "message" : "Unsupported [Content-Type] HTTP request header value of [application/klingon]."
+                           } ]
+                         }
+                        """);
+
+        // Not supported in general, URL does not exist, a fuzzer. Expect a 404
+        simulator.test("/hack-the-planet")
+                .withContentType("application/klingon")
+                .withBody("""
+                        {
+                          "foo": "bar"
+                        }
+                        """)
+                .post()
+                .assertStatusCode(404)
+                .assertBodyContains("The page is missing!");
+    }
+
+    @Test
+    public void post_lotsOfMessagesFromKeys() throws Exception {
+        test.simulate(() -> simulator.test("/lots-of-messages")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContainsMessagesFromKeys(
+                        "message1",
+                        "message2",
+                        "message3",
+                        "message4",
+                        "message5",
+                        "message6",
+                        "message7",
+                        "message8",
+                        "message9",
+                        "message10"));
+
+        // Once for the API call and another for the message lookup
+        assertEquals(LotsOfMessagesAction.invocationCount.get(), 2);
+    }
+
+    @Test
+    public void post_multipart_parameter_mix() throws Exception {
+        // arrange
+        test.createFile("Hello World")
+                .simulate(() -> simulator.test("/user/full-form")
+                        .withParameter("roleIds", 21)
+                        .withParameter("roleIds", 22)
+                        .withURLParameter("ages", 42)
+                        .withParameter("stringField", "hello with space")
+                        .withFile("image", test.tempFile, "text/plain")
+                        .post()
+                        // assert
+                        .assertStatusCode(200));
+
+        assertEquals(FullFormAction.roleIdsFromLastPost.size(), 2);
+        assertEquals(FullFormAction.agesFromLastPost.size(), 1);
+        var fileContents = Files.readString((FullFormAction.imageFromLastPost.getFile()));
+        assertEquals(fileContents, "Hello World");
+        assertEquals(FullFormAction.stringFieldFromLastPost, "hello with space");
+    }
+
+    @Test
+    public void post_objectMapValues() throws Exception {
+        // Dot notation, set into typed map of Map<String, Object>
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.bar.baz", "bing")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-1-response.json")));
+
+        // Bracketed notation - functionally the same as dot. This should produce a map.
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.bar['baz']", "bing")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-2-response.json")));
+
+        // Bracketed notation - functionally the same as dot. This should produce a map.
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.bar['baz']", "bing")
+                .withParameter("foo.bar['baz']", "boom")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-3-response.json")));
+
+        // Bracketed notation using an integer, this is an array.
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.bar[0]", "bing")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-4-response.json")));
+
+        // Bracketed notation using an integer, this is an array.
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.bar[0]", "bing")
+                .withParameter("foo.bar[1]", "boom")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-5-response.json")));
+
+        // Nested properties
+        test.simulate(() -> simulator.test("/object-map-values")
+                .withParameter("foo.data.preferences.coffee.style", "with cream")
+                .withParameter("foo.data.preferences.cars.count", 2)
+                .withParameter("foo.data.preferences.fruit", "oranges")
+                .withParameter("foo.data.preferences.fruit", "apples")
+                .withParameter("foo.data.preferences.fruit", "strawberries")
+                .post()
+                .assertStatusCode(200)
+                .assertJSONFile(jsonDir.resolve("ObjectMapValues-post-test-6-response.json")));
+    }
+
+    @Test
+    public void post_onlyAllowTextHTML() throws Exception {
+        test.createFile("<strong>Hello World</strong>")
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataTextHtml", test.tempFile, "text/plain")
+                        .post()
+                        .assertStatusCode(400))
+                .simulate(() -> simulator.test("/file-upload")
+                        .withFile("dataTextHtml", test.tempFile, "text/html")
+                        .post()
+                        .assertStatusCode(200));
+    }
+
+    @Test
+    public void post_savedRequest_cookieExpired_orCannotBeDeserialized() throws Exception {
+        // Post to a page that requires authentication
+        BaseStoreAction.loggedIn = false;
+        test.simulate(() -> simulator.test("/store/purchase")
+                .withParameter("item", "beer")
+                .post()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/store/login")
+
+                // Redirected to login
+                .executeRedirect(
+                        req -> req.assertStatusCode(200)
+                                .assertHeaderContains("Cache-Control", "no-cache")
+                                .assertBodyContains("Login")
+
+                                // "expire" the flash cookie by rolling the encryption key
+                                .setup(() -> configuration.regenerateCookieEncryptionKey())
+
+                                // Post on Login, get a session, and redirect back to the cart which completes the beer purchase
+                                .executeFormPostInResponseBody("form",
+                                        postReq -> postReq.assertStatusCode(302)
+                                                .assertHeaderContains("Cache-Control", "no-cache")
+                                                .assertRedirect("/store/")
+
+                                                .executeRedirect(
+                                                        redirReq -> redirReq.assertStatusCode(200)
+                                                                // We'll end up on the /store/index instead of completing the save request,
+                                                                // we're logged in, but the beer purchase failed. Sad.
+                                                                .assertBodyContains(
+                                                                        "/store/index",
+                                                                        "IsLoggedIn:true")
+                                                                .assertBodyDoesNotContain("Buy:beer")))));
+    }
+
+    @Test(dataProvider = "purchaseRoutes")
+    public void post_savedRequest_crossOrigin(String route) throws Exception {
+        // Post to a page that requires authentication
+        BaseStoreAction.loggedIn = false;
+
+        // A cross-origin POST request not work with saved request, so expect to just end up at the normal location after login
+        // allow-post-purchase has allowPost = true on the SaveRequest annotation but cross-origin should behave the same
+        test.simulate(() -> simulator.test(route)
+                .withParameter("item", "beer")
+                .withSingleHeader("Origin", "https://hacked.com")
+                .post()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/store/login")
+
+                // Redirected to login
+                .followRedirect(result -> result
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertBodyContains("Login"))
+
+                // Post on Login, get a session, and redirect back to store index, because we threw out the saved request to the cart.
+                .submitForm("form", result -> result
+                        .assertStatusCode(302)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertRedirect("/store/"))
+
+                .followRedirect(result -> result
+                        .assertStatusCode(200)
+                        .assertBody("""
+                                /store/index
+                                IsLoggedIn:true""")
+                        .assertBodyDoesNotContain("Buy:beer")));
+    }
+
+    @Test
+    public void post_savedRequest_sameOriginAllowed() throws Exception {
+        // Post to a page that requires authentication
+        BaseStoreAction.loggedIn = false;
+
+        // Same origin POST request will work with saved request and allowPost =true
+        test.simulate(() -> simulator
+                .test("/store/allow-post-purchase")
+                .withParameter("item", "beer")
+                .post()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/store/login")
+
+                // Redirected to login
+                .followRedirect(result -> result
+                        // assert the request that was made included the correct Referer header
+                        // - We could make this configurable, but for now, it is sending the full header, simulating a Refer policy of same-origin.
+                        //   See RequestResult._followRedirect notes.
+                        .custom(() -> assertEquals(result.request.getHeader("Referer"),
+                                "http://localhost:9080/store/allow-post-purchase"))
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertBodyContains("Login"))
+
+                // Post on Login, get a session, and redirect back to the cart which completes the beer purchase
+                .submitForm("form", result -> result
+                        .assertStatusCode(302)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertRedirect("/store/allow-post-purchase"))
+
+                .followRedirect(result -> result
+                        .assertStatusCode(200)
+                        .assertBody("""
+                                /store/purchase
+                                Buy:beer""")));
+    }
+
+    @Test
+    public void post_savedRequest_sameOriginDenied() throws Exception {
+        // Post to a page that requires authentication
+        BaseStoreAction.loggedIn = false;
+
+        // same origin post saved request will fail if allowPost = false
+        test.simulate(() -> simulator.test("/store/purchase")
+                .withParameter("item", "beer")
+                .post()
+                .assertStatusCode(302)
+                .assertHeaderContains("Cache-Control", "no-cache")
+                .assertRedirect("/store/login")
+
+                // Redirected to login
+                .followRedirect(result -> result
+                        .assertStatusCode(200)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertBodyContains("Login"))
+
+                // Post on Login, get a session, and redirect back to store index, because we threw out the saved request to the cart.
+                .submitForm("form", result -> result
+                        .assertStatusCode(302)
+                        .assertHeaderContains("Cache-Control", "no-cache")
+                        .assertRedirect("/store/"))
+
+                // land on the regular index page
+                .followRedirect(result -> result
+                        .assertStatusCode(200)
+                        .assertBody("""
+                                /store/index
+                                IsLoggedIn:true""")
+                        .assertBodyDoesNotContain("Buy:beer")));
+    }
+
+    @Test
+    public void post_scopeStorage() throws Exception {
+        // Tests that the expression evaluator safely gets skipped while looking for values and Prime then checks the
+        // HttpServletRequest and finds the value
+        test.simulate(() -> simulator.test("/scope-storage")
+                        .post())
+                .assertContextAttributeNotNull("contextObject");
+    }
+
+    @Test
+    public void post_scopeStorageInBaseClass() throws Exception {
+        // Set values during POST - fields exist in base abstract class
+        test.simulate(() -> simulator.test("/extended-scope-storage")
+                        .post())
+                .assertContextAttributeNotNull("contextObject")
+
+                // Call [GET] -- assume everything is set from prior request except request attribute is null.
+                .simulate(() -> simulator.test("/extended-scope-storage")
+                        .get())
+                .assertContextAttributeNotNull("contextObject")
+
+                // Call [GET] on a different action -- only action and context attributes come over, request and action session are null.
+                .simulate(() -> simulator.test("/another-extended-scope-storage")
+                        .get())
+                .assertContextAttributeNotNull("contextObject");
+    }
+
+    @Test
+    public void post_unsupported_multipleParameters() throws Exception {
+        // Cannot jam an array into a non-array data type
+
+        // UUID, two values, no dice.
+        // - We will get a 200, watch the console for the log output.
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withParameter("uuidValue", UUID.randomUUID())
+                .withParameter("uuidValue", UUID.randomUUID())
+                .post()
+                .assertStatusCode(500)
+                .assertBodyIsEmpty());
+
+        TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
+                "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type UUID. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [uuidValue]"));
+
+        // Enum, two values, no dice
+        // - We will get a 200, watch the console for the log output.
+        test.simulate(() -> simulator.test("/parameter-handler")
+                .withParameter("enumValue", ParameterHandlerAction.Fruit.Orange)
+                .withParameter("enumValue", ParameterHandlerAction.Fruit.Apple)
+                .post()
+                .assertStatusCode(500)
+                .assertBodyIsEmpty());
+
+        TestUnhandledExceptionHandler.assertLastUnhandledException(new MultipleParametersUnsupportedException(
+                "You are attempting to map a form field that contains multiple parameters to a property on the action class that is of type Enum. This isn't allowed. Action class [org.example.action.ParameterHandlerAction] Request URI [/parameter-handler] Parameter name [enumValue]"));
+    }
+
+    @Test
+    public void post_withURLParameter_IndexAmbiguity() {
+        // https://github.com/FusionAuth/fusionauth-issues/issues/434
+
+        // Add a trailing slash when the URL parameter is {userId} which is a UUID
+        // - Ok, it is ignored and there are no conversion exceptions
+        simulator.test("/api/action-value/login/")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
+
+        // Manually added the 'index' suffix, expect a couldNotConvert error because this is not a UUID
+        simulator.test("/api/action-value/login/index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsFieldErrors("userId")
+                .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
+
+        // Leave a trailing slash and pass an invalid type for userId as a request parameter
+        simulator.test("/api/action-value/login/")
+                .withParameter("userId", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsFieldErrors("userId")
+                .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
+
+        // No trailing slash and pass an invalid type for userId as a request parameter
+        simulator.test("/api/action-value/login")
+                .withParameter("userId", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsFieldErrors("userId")
+                .assertBodyContains("/api/action-value/login", "potato:null", "userId:null");
+
+        // Leave a trailing slash and use a separate variable with the name 'index'
+        simulator.test("/api/action-value/login/")
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/login", "potato:index", "userId:null");
+
+        // Correct usage, URL parameter with the correct type.
+        UUID userId = UUID.randomUUID();
+        simulator.test("/api/action-value/login")
+                .withURLSegment(userId)
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/login", "potato:index", "userId:" + userId);
+
+        // With a real Index page, add a URL parameter, add a separate request parameter with a value of index
+        simulator.test("/api/action-value/index")
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/index", "potato:index", "userId:null");
+
+        // Real Index page, add a trailing slash when the URL parameter is a UUID
+        // - The trailing slash should be ignored, no errors
+        simulator.test("/api/action-value/index/")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/index", "potato:null", "userId:null");
+
+        // Real Index page, with a legit UUID on the URL
+        simulator.test("/api/action-value/index/" + userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
+
+        // Real Index page, with a legit UUID using a URL segment and a trailing slash
+        simulator.test("/api/action-value/index/")
+                .withURLSegment(userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
+
+        // Real Index page, with a legit UUID using a URL segment and no trailing slash
+        simulator.test("/api/action-value/index")
+                .withURLSegment(userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/action-value/index", "potato:null", "userId:" + userId);
+    }
+
+    @Test
+    public void post_withoutURLParameter_IndexAmbiguity() {
+        // https://github.com/FusionAuth/fusionauth-issues/issues/434
+
+        // Add a trailing slash when the URL parameter is {userId} which is a UUID
+        // - Ok, it is ignored and there are no conversion exceptions
+        simulator.test("/api/no-action-value/login/")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
+
+        // All of these will be ignored
+        simulator.test("/api/no-action-value/login/foo/bar/baz")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
+
+        // Manually added the 'index' suffix, not expect a URL segment, so it is ignored.
+        simulator.test("/api/no-action-value/login/index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
+
+        // Leave a trailing slash and pass an invalid type for userId as a request parameter
+        simulator.test("/api/no-action-value/login/")
+                .withParameter("userId", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsFieldErrors("userId")
+                .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
+
+        // No trailing slash and pass an invalid type for userId as a request parameter
+        simulator.test("/api/no-action-value/login")
+                .withParameter("userId", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsFieldErrors("userId")
+                .assertBodyContains("/api/no-action-value/login", "potato:null", "userId:null");
+
+        // Leave a trailing slash and use a separate variable with the name 'index'
+        simulator.test("/api/no-action-value/login/")
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:null");
+
+        // URL parameter is ignored since the Action is not configured to take a URL parameter
+        UUID userId = UUID.randomUUID();
+        simulator.test("/api/no-action-value/login")
+                .withURLSegment(userId)
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:null");
+
+        // userId and potato are taking as request parameters, bonzai!
+        simulator.test("/api/no-action-value/login")
+                .withURLSegment(userId)
+                .withParameter("potato", "index")
+                .withParameter("userId", userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/login", "potato:index", "userId:" + userId);
+
+        // With a real Index page, add a URL parameter, add a separate request parameter with a value of index
+        simulator.test("/api/no-action-value/index")
+                .withParameter("potato", "index")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/index", "potato:index", "userId:null");
+
+        // Real Index page, add a trailing slash when the URL parameter is a UUID
+        // - The trailing slash should be ignored, no errors
+        simulator.test("/api/no-action-value/index/")
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
+
+        // Real Index page, with a legit UUID on the URL but it is ignored because are not capturing URL parameters
+        simulator.test("/api/no-action-value/index/" + userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
+
+        // Real Index page, with a legit UUID using a URL segment and a trailing slash, ignored.
+        simulator.test("/api/no-action-value/index/")
+                .withURLSegment(userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
+
+        // Real Index page, with a legit UUID using a URL segment and no trailing slash, ignored
+        simulator.test("/api/no-action-value/index")
+                .withURLSegment(userId)
+                .post()
+                .assertStatusCode(200)
+                .assertContainsNoFieldMessages()
+                .assertBodyContains("/api/no-action-value/index", "potato:null", "userId:null");
+    }
+
+    @DataProvider
+    public Object[][] purchaseRoutes() {
+        return new Object[][]{
+                {"/store/purchase"},
+                {"/store/allow-post-purchase"}
+        };
+    }
+
+    @Test
+    public void singletons() {
+        assertSingleton(ActionConfigurationProvider.class);
+        assertSingleton(Configuration.class);
+        assertSingleton(ResourceBundle.Control.class);
+        assertSingleton(ResourceBundle.Control.class);
+        assertSingleton(ContainerResolver.class);
+        assertSingleton(ConverterProvider.class);
+        assertSingleton(ExpressionEvaluator.class);
+        assertSingleton(URIBuilder.class);
+        assertSingletonConverter(Boolean.class);
+        assertSingletonConverter(boolean.class);
+        assertSingletonConverter(Character.class);
+        assertSingletonConverter(char.class);
+        assertSingletonConverter(Number.class);
+        assertSingletonConverter(int.class);
+        assertSingletonConverter(long.class);
+        assertSingletonConverter(double.class);
+        assertSingletonConverter(float.class);
+        assertSingletonConverter(BigDecimal.class);
+        assertSingletonConverter(BigInteger.class);
+        assertSingletonConverter(Collection.class);
+        assertSingletonConverter(ZonedDateTime.class);
+        assertSingletonConverter(Enum.class);
+        assertSingletonConverter(File.class);
+        assertSingletonConverter(LocalDate.class);
+        assertSingletonConverter(Locale.class);
+        assertSingletonConverter(String.class);
+    }
+
+    @Test
+    public void uriParameters() throws Exception {
+        test.simulate(() -> simulator.test("/complex-rest/brian/static/pontarelli/then/a/bunch/of/stuff")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("firstName=brian", "lastName=pontarelli", "theRest=then,a,bunch,of,stuff"));
+    }
+
+    private void assertSingleton(Class<?> type) {
+        assertSame(injector.getInstance(type), injector.getInstance(type));
+    }
+
+    private void assertSingletonConverter(Class<?> type) {
+        // Adding a noinspection, there is a bug in the JDK that is exposed when you take the suggestion of IJ and replace this TypeLiteral type info with <>
+        // Ask me how I know... see https://stackoverflow.com/questions/50885335/java-10-compilaton-null-pointer-exception
+        //noinspection Convert2Diamond
+        Map<Class<?>, GlobalConverter> converters = injector.getInstance(Key.get(new TypeLiteral<Map<Class<?>, GlobalConverter>>() {
+        }));
+        assertSame(converters.get(type), converters.get(type));
+    }
+
+    private byte[] readBytes(String path) {
+        try {
+            return Files.readAllBytes(Path.of(path));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/test/java/org/primeframework/mvc/LocaleActionTest.java
+++ b/src/test/java/org/primeframework/mvc/LocaleActionTest.java
@@ -15,51 +15,52 @@
  */
 package org.primeframework.mvc;
 
-import java.util.Locale;
-
+import io.fusionauth.http.Cookie;
 import org.testng.annotations.Test;
+
+import java.util.Locale;
 
 /**
  * @author Brian Pontarelli
  */
 @Test
 public class LocaleActionTest extends PrimeBaseTest {
-  @Test
-  public void getFromBrowser() {
-    simulator.test("/locale")
-             .withHeader("Accept-Language", Locale.CHINESE.toString())
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Locale:zh");
-  }
+    @Test
+    public void getFromBrowser() {
+        simulator.test("/locale")
+                .withHeader("Accept-Language", Locale.CHINESE.toString())
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Locale:zh");
+    }
 
-  @Test
-  public void getFromCookie() throws Exception {
-    // The cookie overrides the header
-    simulator.test("/locale")
-             .withHeader("Accept-Language", Locale.CHINESE.toString())
-             .withCookie("prime-locale", "fr")
-             .get()
-             .assertStatusCode(200)
-             .assertBodyContains("Locale:fr");
-  }
+    @Test
+    public void getFromCookie() throws Exception {
+        // The cookie overrides the header
+        simulator.test("/locale")
+                .withHeader("Accept-Language", Locale.CHINESE.toString())
+                .withCookie(new Cookie("prime-locale", "fr"))
+                .get()
+                .assertStatusCode(200)
+                .assertBodyContains("Locale:fr");
+    }
 
-  @Test
-  public void set() {
-    simulator.test("/locale")
-             .withParameter("locale", "zh")
-             .post()
-             .assertStatusCode(200)
-             .assertBodyContains("Locale:zh")
-             .assertCookie("prime-locale", "zh");
-  }
+    @Test
+    public void set() {
+        simulator.test("/locale")
+                .withParameter("locale", "zh")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("Locale:zh")
+                .assertCookie("prime-locale", "zh");
+    }
 
-  @Test
-  public void setDeleteCookie() {
-    simulator.test("/locale")
-             .post()
-             .assertStatusCode(200)
-             .assertBodyContains("Locale:empty")
-             .assertCookieWasDeleted("prime-locale");
-  }
+    @Test
+    public void setDeleteCookie() {
+        simulator.test("/locale")
+                .post()
+                .assertStatusCode(200)
+                .assertBodyContains("Locale:empty")
+                .assertCookieWasDeleted("prime-locale");
+    }
 }

--- a/src/test/java/org/primeframework/mvc/ManagedCookieTest.java
+++ b/src/test/java/org/primeframework/mvc/ManagedCookieTest.java
@@ -55,7 +55,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
 
         // Send the bad cookie value directly on a GET request to avoid it being written by PMVC
         simulator.test("/managed-cookie")
-                .withCookie("cookie", badCookieValue)
+                .withCookie(new Cookie("cookie", badCookieValue))
                 .get()
                 // The cookie is base64-decoded and parsed as JSON
                 .assertBody("5")
@@ -97,7 +97,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
         var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
         var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
         test.simulate(() -> simulator.test("/compressed-managed-cookie")
-                        .withCookie("cookie", legacyCookieWithNoCompression)
+                        .withCookie(new Cookie("cookie", legacyCookieWithNoCompression))
                         .get()
                         .assertStatusCode(200)
                         .assertBody(value)
@@ -126,7 +126,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
         var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
         var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
         test.simulate(() -> simulator.test("/compressed-managed-cookie")
-                        .withCookie("cookie", legacyCookieWithNoCompression)
+                        .withCookie(new Cookie("cookie", legacyCookieWithNoCompression))
                         .get()
                         .assertStatusCode(200)
                         .assertBody(value)
@@ -187,7 +187,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
 
         // Make a request with the raw cookie value included in the header
         test.simulate(() -> simulator.test("/managed-cookie")
-                        .withCookie("cookie", cookie)
+                        .withCookie(new Cookie("cookie", cookie))
                         .get()
                         .assertStatusCode(200)
                         // The body contains string after removing header bytes
@@ -242,7 +242,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
         // This is the legacy version, but it should work even though the EncryptedManagedCookieAction
         // has compression enabled
         test.simulate(() -> simulator.test("/encrypted-managed-cookie")
-                        .withCookie("cookie", legacyEncoded)
+                        .withCookie(new Cookie("cookie", legacyEncoded))
                         .get()
                         .assertStatusCode(200)
                         .assertNormalizedBody("foo")
@@ -357,6 +357,7 @@ public class ManagedCookieTest extends PrimeBaseTest {
 
         // The first request is a modern, base64-encoded cookie with headers. The value is the JSON String `"foo"`
         test.simulate(() -> simulator.test("/managed-cookie")
+                // direct Cookie constructor will not put a header on the value
                 .withCookie(new Cookie("cookie", jsonStr))
                 .get()
                 .assertStatusCode(200)

--- a/src/test/java/org/primeframework/mvc/ManagedCookieTest.java
+++ b/src/test/java/org/primeframework/mvc/ManagedCookieTest.java
@@ -15,15 +15,16 @@
  */
 package org.primeframework.mvc;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import com.google.inject.Inject;
+import io.fusionauth.http.Cookie;
 import org.primeframework.mvc.security.CBCCipherProvider;
 import org.primeframework.mvc.security.DefaultEncryptor;
 import org.primeframework.mvc.security.Encryptor;
 import org.primeframework.mvc.util.CookieTools;
 import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * This class tests managed cookies.
@@ -31,345 +32,346 @@ import org.testng.annotations.Test;
  * @author Brian Pontarelli
  */
 public class ManagedCookieTest extends PrimeBaseTest {
-  @Inject private Encryptor encryptor;
+    @Inject
+    private Encryptor encryptor;
 
-  @Test
-  public void broken_csrf_case() throws Exception {
-    // Use case: this covers a situation that was thought to only come up in CSRF testing, but it turns out that it was possible with any cookie
-    //  that is not compressed or encrypted.
-    // 1) An action uses a @ManagedCookie or @ManagedSessionCookie with compress=false / encrypt=false
-    // 2) When the action is requested, BaseManagedCookieScope.processCookie() attempts to parse the base64-encoded cookie value as a legacy cookie (no header bytes)
-    // 3) The function applied for parsing in this case attempts to parse the value as a JSON string using Jackson
-    // 4) If base64-decoded cookie value starts with valid JSON followed by a newline (\n, 0x0a, 10) character, Jackson stops its parsing at that point at returns the
-    //    JSON value before the newline.
-    //
-    // The fix is to add the header byte prefix before base64-encoding the value for all cookies going forward. Cookie parsing has not been updated in
-    //  order to maintain backward compatibility. This test demonstrates the bug that exists in cookie parsing and shows that the new MVC cookie-writing
-    //  logic that includes the header bytes means that the same payload can be written and read back properly.
+    @Test
+    public void broken_csrf_case() throws Exception {
+        // Use case: this covers a situation that was thought to only come up in CSRF testing, but it turns out that it was possible with any cookie
+        //  that is not compressed or encrypted.
+        // 1) An action uses a @ManagedCookie or @ManagedSessionCookie with compress=false / encrypt=false
+        // 2) When the action is requested, BaseManagedCookieScope.processCookie() attempts to parse the base64-encoded cookie value as a legacy cookie (no header bytes)
+        // 3) The function applied for parsing in this case attempts to parse the value as a JSON string using Jackson
+        // 4) If base64-decoded cookie value starts with valid JSON followed by a newline (\n, 0x0a, 10) character, Jackson stops its parsing at that point at returns the
+        //    JSON value before the newline.
+        //
+        // The fix is to add the header byte prefix before base64-encoding the value for all cookies going forward. Cookie parsing has not been updated in
+        //  order to maintain backward compatibility. This test demonstrates the bug that exists in cookie parsing and shows that the new MVC cookie-writing
+        //  logic that includes the header bytes means that the same payload can be written and read back properly.
 
-    // When base64-decoded, the beginning of this cookie value is "5\n". When a cookie does not contain the header bytes, we attempt to
-    //  parse the value as a JSON string. Jackson interprets the \n as the end of the JSON string, and the number 5 is valid JSON.
-    var badCookieValue = "NQryyR_pFrynPybHfMk_4Hka_J0HZ1WV6iVVWVki0mVg-WpdVkk2HO8_XQ46yhw8_w==";
+        // When base64-decoded, the beginning of this cookie value is "5\n". When a cookie does not contain the header bytes, we attempt to
+        //  parse the value as a JSON string. Jackson interprets the \n as the end of the JSON string, and the number 5 is valid JSON.
+        var badCookieValue = "NQryyR_pFrynPybHfMk_4Hka_J0HZ1WV6iVVWVki0mVg-WpdVkk2HO8_XQ46yhw8_w==";
 
-    // Send the bad cookie value directly on a GET request to avoid it being written by PMVC
-    simulator.test("/managed-cookie")
-             .withCookie("cookie", badCookieValue)
-             .get()
-             // The cookie is base64-decoded and parsed as JSON
-             .assertBody("5")
-             // The new cookie value is written with the header and base64-encoded
-             .assertCookie("cookie", CookieTools.toCookie("5".getBytes(), false, false, encryptor));
+        // Send the bad cookie value directly on a GET request to avoid it being written by PMVC
+        simulator.test("/managed-cookie")
+                .withCookie("cookie", badCookieValue)
+                .get()
+                // The cookie is base64-decoded and parsed as JSON
+                .assertBody("5")
+                // The new cookie value is written with the header and base64-encoded
+                .assertCookie("cookie", CookieTools.toCookie("5".getBytes(), false, false, encryptor));
 
-    // Make a second GET request with the cookie. No change in rendered value or cookie value
-    simulator.test("/managed-cookie")
-             .get()
-             .assertBody("5")
-             .assertCookie("cookie", CookieTools.toCookie("5".getBytes(), false, false, encryptor));
+        // Make a second GET request with the cookie. No change in rendered value or cookie value
+        simulator.test("/managed-cookie")
+                .get()
+                .assertBody("5")
+                .assertCookie("cookie", CookieTools.toCookie("5".getBytes(), false, false, encryptor));
 
-    // Make a request to set the cookie value via the PMVC annotation
-    simulator.test("/managed-cookie")
-             .withParameter("value", badCookieValue)
-             .post()
-             // The original value is available to the action (technically comes from the "value" parameter directly in this case)
-             .assertBody(badCookieValue)
-             // The cookie value is prefaced with a header
-             .assertCookie("cookie", CookieTools.toCookie(badCookieValue.getBytes(), false, false, encryptor));
+        // Make a request to set the cookie value via the PMVC annotation
+        simulator.test("/managed-cookie")
+                .withParameter("value", badCookieValue)
+                .post()
+                // The original value is available to the action (technically comes from the "value" parameter directly in this case)
+                .assertBody(badCookieValue)
+                // The cookie value is prefaced with a header
+                .assertCookie("cookie", CookieTools.toCookie(badCookieValue.getBytes(), false, false, encryptor));
 
-    // Make a GET request with the existing cookie value. No change.
-    simulator.test("/managed-cookie")
-             .get()
-             .assertBody(badCookieValue)
-             .assertCookie("cookie", CookieTools.toCookie(badCookieValue.getBytes(), false, false, encryptor));
-  }
+        // Make a GET request with the existing cookie value. No change.
+        simulator.test("/managed-cookie")
+                .get()
+                .assertBody(badCookieValue)
+                .assertCookie("cookie", CookieTools.toCookie(badCookieValue.getBytes(), false, false, encryptor));
+    }
 
-  @Test
-  public void compressed_annotation_legacy_uncompressed_cookie_longer_than_5() throws Exception {
-    // Scenario:
-    // 1) Browser has uncompressed, non-encrypted cookie with value 'foobar' from a long time ago
-    // 2) Application decides to start compressing (but not encrypting) cookie. Adds @ManagedCookie(compress = true, encrypt = false)
-    // to app
-    // 3) Browser submits cookie
+    @Test
+    public void compressed_annotation_legacy_uncompressed_cookie_longer_than_5() throws Exception {
+        // Scenario:
+        // 1) Browser has uncompressed, non-encrypted cookie with value 'foobar' from a long time ago
+        // 2) Application decides to start compressing (but not encrypting) cookie. Adds @ManagedCookie(compress = true, encrypt = false)
+        // to app
+        // 3) Browser submits cookie
 
-    var value = "foobar";
-    byte[] json = objectMapper.writeValueAsBytes(value);
-    var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
-    var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
-    test.simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .withCookie("cookie", legacyCookieWithNoCompression)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody(value)
-                                 // Expected result is modern format with 0x42 3 times...
-                                 .assertCookie("cookie", modernCookie))
+        var value = "foobar";
+        byte[] json = objectMapper.writeValueAsBytes(value);
+        var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
+        var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
+        test.simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .withCookie("cookie", legacyCookieWithNoCompression)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody(value)
+                        // Expected result is modern format with 0x42 3 times...
+                        .assertCookie("cookie", modernCookie))
+
+                // The request works a second time with the updated cookie
+                .simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody(value)
+                        .assertCookie("cookie", modernCookie))
+        ;
+    }
+
+    @Test
+    public void compressed_annotation_legacy_uncompressed_cookie_shorter_than_5() throws Exception {
+        // Scenario:
+        // 1) Browser has uncompressed, non-encrypted cookie with value 'f' from a long time ago
+        // 2) Application decides to start compressing (but not encrypting) cookie. Adds @ManagedCookie(compress = true, encrypt = false)
+        // to app
+        // 3) Browser submits cookie
+
+        var value = "f";
+        byte[] json = objectMapper.writeValueAsBytes(value);
+        var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
+        var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
+        test.simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .withCookie("cookie", legacyCookieWithNoCompression)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody(value)
+                        // Expected result is modern format with 0x42 3 times...
+                        .assertCookie("cookie", modernCookie)
+                )
+
+                // The request works a second time with the updated cookie
+                .simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody(value)
+                        .assertCookie("cookie", modernCookie))
+        ;
+    }
+
+    @Test
+    public void compressed_only_cookie() throws Exception {
+        // Browser sets cookie for the first time
+        test.simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .withParameter("value", "bar")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertBody("bar")
+                        .assertCookie("cookie", CookieTools.toCookie("bar".getBytes(), true, false, encryptor))
+                )
+                // modern (compressed, not encrypted) cookie is now set in our simulator user agent
+                .simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody("bar")
+                        .assertCookie("cookie", CookieTools.toCookie("bar".getBytes(), true, false, encryptor))
+                )
+                // Test the compressed-only cookie on a page that requires the cookie to be encrypted.
+                .simulate(() -> simulator.test("/encrypted-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        // Failed to decrypt the cookie, but it failed gracefully (neverNull is true).
+                        // The body does not contain the cookie value.
+                        .assertNormalizedBody("(null)")
+                        // The cookie was deleted because it failed parsing.
+                        .assertCookieWasDeleted("cookie")
+                )
+                // Making the request back to the compressed page will not find the cookie
+                .simulate(() -> simulator.test("/compressed-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody("(null)")
+                        .assertDoesNotContainsCookie("cookie")
+                );
+    }
+
+    @Test
+    public void cookie_accidentally_starts_with_header() throws Exception {
+        // A cookie that happens to start with the header will be interpreted accordingly
+        // BBB<null>BB
+        var cookie = "QkJCAEJC";
+
+        // Make a request with the raw cookie value included in the header
+        test.simulate(() -> simulator.test("/managed-cookie")
+                        .withCookie("cookie", cookie)
+                        .get()
+                        .assertStatusCode(200)
+                        // The body contains string after removing header bytes
+                        .assertBody("BB")
+                        // The new cookie value has header bytes and is encoded
+                        .assertCookie("cookie", cookie))
+                // A second request using the cookie value set in user agent behaves the same
+                .simulate(() -> simulator.test("/managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertBody("BB")
+                        .assertCookie("cookie", cookie));
+    }
+
+    @Test
+    public void cookie_is_base64_encoded_without_header() throws Exception {
+        // Use case: a cookie that is base64-encoded before being written by PMVC will still be base64-encoded when reading back.
+        String cookie = Base64.getEncoder().encodeToString("foobar".getBytes());
+
+        // Provide the base64-encoded value as a legacy cookie without headers by including directly on request.
+        test.simulate(() -> simulator.test("/managed-cookie")
+                .withCookie("cookie", cookie)
+                .get()
+                .assertStatusCode(200)
+                // The rendered value is not decoded
+                .assertBody(cookie)
+                // The cookie will be updated with a header
+                .assertCookie("cookie", CookieTools.toCookie(cookie.getBytes(), false, false, encryptor)));
+
+        // Make a second GET request with the updated cookie. No change to body or cookie value
+        test.simulate(() -> simulator.test("/managed-cookie")
+                .get()
+                .assertStatusCode(200)
+                .assertBody(cookie)
+                .assertCookie("cookie", CookieTools.toCookie(cookie.getBytes(), false, false, encryptor)));
+    }
+
+    @Test
+    public void legacy_cookie() throws Exception {
+        // Scenario:
+        // 1) Browser has uncompressed, AES/CBC-encrypted cookie with value '"foo"' from a long time ago
+        // 2) Application upgrades to the modern cookie format with header, etc.
+        // 3) Browser submits cookie
+        String value = "foo";
+        byte[] json = objectMapper.writeValueAsBytes(value);
+        // We want to use the deprecated encrypt method to test forward compatibility with the new decryption method
+        // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
+        Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
+        byte[] legacyEncrypted = cbcEncryptor.encrypt(json);
+        String legacyEncoded = Base64.getUrlEncoder().encodeToString(legacyEncrypted);
+
+        // This is the legacy version, but it should work even though the EncryptedManagedCookieAction
+        // has compression enabled
+        test.simulate(() -> simulator.test("/encrypted-managed-cookie")
+                        .withCookie("cookie", legacyEncoded)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertNormalizedBody("foo")
+                        // during the get, our cookie is modernized
+                        .assertEncryptedCookie("cookie", "foo"))
+
+                // Set a modern version and re-test
+                .simulate(() -> simulator.test("/encrypted-managed-cookie")
+                        .withParameter("value", "bar")
+                        .post()
+                        .assertStatusCode(200)
+                        .assertNormalizedBody("bar")
+                        .assertEncryptedCookie("cookie", "bar"))
+                .simulate(() -> simulator.test("/encrypted-managed-cookie")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertNormalizedBody("bar"));
+    }
+
+    @Test
+    public void managed_cookie_scope() throws Exception {
+        // Test use of multiple cookies on a single action
+        var fooCookie = CookieTools.toCookie("foo".getBytes(), false, false, encryptor);
+        var barCookie = CookieTools.toCookie("bar".getBytes(), false, false, encryptor);
+        var bazCookie = CookieTools.toCookie("baz".getBytes(), false, false, encryptor);
+
+        // Values are not set, no cookies
+        test.simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertDoesNotContainsCookie("cookie1")
+                        .assertDoesNotContainsCookie("cookie2")
+                        // there should never be this one, it is named 'fusionauth.sso'
+                        .assertDoesNotContainsCookie("cookie3")
+                        .assertDoesNotContainsCookie("fusionauth.sso"))
+
+                // Write all three cookies
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .withURLParameter("writeCookie1", "foo")
+                        .withURLParameter("writeCookie2", "bar")
+                        .withURLParameter("writeCookie3", "baz")
+                        .get()
+                        .assertStatusCode(200)
+                        // The cookies are written in new format
+                        .assertCookie("cookie1", fooCookie)
+                        .assertCookie("cookie2", barCookie)
+                        .assertCookie("fusionauth.sso", bazCookie)
+                )
+
+                // Cookies are persisted, hit the GET, and they will still be there.
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertCookie("cookie1", fooCookie)
+                        .assertCookie("cookie2", barCookie)
+                        .assertCookie("fusionauth.sso", bazCookie)
+                )
+
+                // Delete stringCookie2
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .withURLParameter("deleteCookie2", true)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertCookie("cookie1", fooCookie)
+                        .assertCookieWasDeleted("cookie2")
+                        .assertCookie("fusionauth.sso", bazCookie))
+
+                // Next request stringCookie2 will be all the way gone
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertCookie("cookie1", fooCookie)
+                        .assertDoesNotContainsCookie("cookie2")
+                        .assertCookie("fusionauth.sso", bazCookie))
+
+                // stringCookie1 and stringCookie3 holding strong after another request
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertCookie("cookie1", fooCookie)
+                        .assertDoesNotContainsCookie("cookie2")
+                        .assertCookie("fusionauth.sso", bazCookie))
+
+                // Delete all of them!!! - 1 and 3
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .withURLParameter("deleteCookie1", true)
+                        .withURLParameter("deleteCookie3", true)
+                        .get()
+                        .assertStatusCode(200)
+                        .assertCookieWasDeleted("cookie1")
+                        .assertDoesNotContainsCookie("cookie2")
+                        .assertCookieWasDeleted("fusionauth.sso"))
+
+                // They are now all gone.
+                .simulate(() -> simulator.test("/managed-cookie-scopes")
+                        .get()
+                        .assertStatusCode(200)
+                        .assertDoesNotContainsCookie("cookie1")
+                        .assertDoesNotContainsCookie("cookie2")
+                        .assertDoesNotContainsCookie("fusionauth.sso"));
+    }
+
+    @Test
+    public void uncompressed_unencrypted_contains_json() throws Exception {
+        // 1) The legacy cookie contains a value that can be parsed as JSON
+        // 2) The cookie is parsed, and the value is displayed as a JSON string
+        // 3) The cookie is rewritten in the modern format with a header
+        // 4) The follow-up request with the modern cookie still renders the JSON string
+        String value = "foo"; // `foo`
+        byte[] json = objectMapper.writeValueAsBytes(value); // `"foo"`
+        String jsonStr = new String(json, StandardCharsets.UTF_8);
+
+        // The first request is a modern, base64-encoded cookie with headers. The value is the JSON String `"foo"`
+        test.simulate(() -> simulator.test("/managed-cookie")
+                .withCookie(new Cookie("cookie", jsonStr))
+                .get()
+                .assertStatusCode(200)
+                // `"foo"` is rendered
+                .assertBody(jsonStr)
+                // The new cookie is written in the modern format
+                .assertCookie("cookie", CookieTools.toCookie(json, false, false, encryptor)));
 
         // The request works a second time with the updated cookie
-        .simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody(value)
-                                 .assertCookie("cookie", modernCookie))
-    ;
-  }
-
-  @Test
-  public void compressed_annotation_legacy_uncompressed_cookie_shorter_than_5() throws Exception {
-    // Scenario:
-    // 1) Browser has uncompressed, non-encrypted cookie with value 'f' from a long time ago
-    // 2) Application decides to start compressing (but not encrypting) cookie. Adds @ManagedCookie(compress = true, encrypt = false)
-    // to app
-    // 3) Browser submits cookie
-
-    var value = "f";
-    byte[] json = objectMapper.writeValueAsBytes(value);
-    var legacyCookieWithNoCompression = Base64.getEncoder().encodeToString(json);
-    var modernCookie = CookieTools.toCookie(value.getBytes(), true, false, encryptor);
-    test.simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .withCookie("cookie", legacyCookieWithNoCompression)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody(value)
-                                 // Expected result is modern format with 0x42 3 times...
-                                 .assertCookie("cookie", modernCookie)
-        )
-
-        // The request works a second time with the updated cookie
-        .simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody(value)
-                                 .assertCookie("cookie", modernCookie))
-    ;
-  }
-
-  @Test
-  public void compressed_only_cookie() throws Exception {
-    // Browser sets cookie for the first time
-    test.simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .withParameter("value", "bar")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertBody("bar")
-                                 .assertCookie("cookie", CookieTools.toCookie("bar".getBytes(), true, false, encryptor))
-        )
-        // modern (compressed, not encrypted) cookie is now set in our simulator user agent
-        .simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody("bar")
-                                 .assertCookie("cookie", CookieTools.toCookie("bar".getBytes(), true, false, encryptor))
-        )
-        // Test the compressed-only cookie on a page that requires the cookie to be encrypted.
-        .simulate(() -> simulator.test("/encrypted-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // Failed to decrypt the cookie, but it failed gracefully (neverNull is true).
-                                 // The body does not contain the cookie value.
-                                 .assertNormalizedBody("(null)")
-                                 // The cookie was deleted because it failed parsing.
-                                 .assertCookieWasDeleted("cookie")
-        )
-        // Making the request back to the compressed page will not find the cookie
-        .simulate(() -> simulator.test("/compressed-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody("(null)")
-                                 .assertDoesNotContainsCookie("cookie")
-        );
-  }
-
-  @Test
-  public void cookie_accidentally_starts_with_header() throws Exception {
-    // A cookie that happens to start with the header will be interpreted accordingly
-    // BBB<null>BB
-    var cookie = "QkJCAEJC";
-
-    // Make a request with the raw cookie value included in the header
-    test.simulate(() -> simulator.test("/managed-cookie")
-                                 .withCookie("cookie", cookie)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // The body contains string after removing header bytes
-                                 .assertBody("BB")
-                                 // The new cookie value has header bytes and is encoded
-                                 .assertCookie("cookie", cookie))
-        // A second request using the cookie value set in user agent behaves the same
-        .simulate(() -> simulator.test("/managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody("BB")
-                                 .assertCookie("cookie", cookie));
-  }
-
-  @Test
-  public void cookie_is_base64_encoded_without_header() throws Exception {
-    // Use case: a cookie that is base64-encoded before being written by PMVC will still be base64-encoded when reading back.
-    String cookie = Base64.getEncoder().encodeToString("foobar".getBytes());
-
-    // Provide the base64-encoded value as a legacy cookie without headers by including directly on request.
-    test.simulate(() -> simulator.test("/managed-cookie")
-                                 .withCookie("cookie", cookie)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // The rendered value is not decoded
-                                 .assertBody(cookie)
-                                 // The cookie will be updated with a header
-                                 .assertCookie("cookie", CookieTools.toCookie(cookie.getBytes(), false, false, encryptor)));
-
-    // Make a second GET request with the updated cookie. No change to body or cookie value
-    test.simulate(() -> simulator.test("/managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertBody(cookie)
-                                 .assertCookie("cookie", CookieTools.toCookie(cookie.getBytes(), false, false, encryptor)));
-  }
-
-  @Test
-  public void legacy_cookie() throws Exception {
-    // Scenario:
-    // 1) Browser has uncompressed, AES/CBC-encrypted cookie with value '"foo"' from a long time ago
-    // 2) Application upgrades to the modern cookie format with header, etc.
-    // 3) Browser submits cookie
-    String value = "foo";
-    byte[] json = objectMapper.writeValueAsBytes(value);
-    // We want to use the deprecated encrypt method to test forward compatibility with the new decryption method
-    // Instantiate DefaultEncryptor with two copies of CBCCipherProvider to encrypt with CBC
-    Encryptor cbcEncryptor = new DefaultEncryptor(new CBCCipherProvider(configuration), new CBCCipherProvider(configuration));
-    byte[] legacyEncrypted = cbcEncryptor.encrypt(json);
-    String legacyEncoded = Base64.getUrlEncoder().encodeToString(legacyEncrypted);
-
-    // This is the legacy version, but it should work even though the EncryptedManagedCookieAction
-    // has compression enabled
-    test.simulate(() -> simulator.test("/encrypted-managed-cookie")
-                                 .withCookie("cookie", legacyEncoded)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertNormalizedBody("foo")
-                                 // during the get, our cookie is modernized
-                                 .assertEncryptedCookie("cookie", "foo"))
-
-        // Set a modern version and re-test
-        .simulate(() -> simulator.test("/encrypted-managed-cookie")
-                                 .withParameter("value", "bar")
-                                 .post()
-                                 .assertStatusCode(200)
-                                 .assertNormalizedBody("bar")
-                                 .assertEncryptedCookie("cookie", "bar"))
-        .simulate(() -> simulator.test("/encrypted-managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertNormalizedBody("bar"));
-  }
-
-  @Test
-  public void managed_cookie_scope() throws Exception {
-    // Test use of multiple cookies on a single action
-    var fooCookie = CookieTools.toCookie("foo".getBytes(), false, false, encryptor);
-    var barCookie = CookieTools.toCookie("bar".getBytes(), false, false, encryptor);
-    var bazCookie = CookieTools.toCookie("baz".getBytes(), false, false, encryptor);
-
-    // Values are not set, no cookies
-    test.simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertDoesNotContainsCookie("cookie1")
-                                 .assertDoesNotContainsCookie("cookie2")
-                                 // there should never be this one, it is named 'fusionauth.sso'
-                                 .assertDoesNotContainsCookie("cookie3")
-                                 .assertDoesNotContainsCookie("fusionauth.sso"))
-
-        // Write all three cookies
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .withURLParameter("writeCookie1", "foo")
-                                 .withURLParameter("writeCookie2", "bar")
-                                 .withURLParameter("writeCookie3", "baz")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // The cookies are written in new format
-                                 .assertCookie("cookie1", fooCookie)
-                                 .assertCookie("cookie2", barCookie)
-                                 .assertCookie("fusionauth.sso", bazCookie)
-        )
-
-        // Cookies are persisted, hit the GET, and they will still be there.
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertCookie("cookie1", fooCookie)
-                                 .assertCookie("cookie2", barCookie)
-                                 .assertCookie("fusionauth.sso", bazCookie)
-        )
-
-        // Delete stringCookie2
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .withURLParameter("deleteCookie2", true)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertCookie("cookie1", fooCookie)
-                                 .assertCookieWasDeleted("cookie2")
-                                 .assertCookie("fusionauth.sso", bazCookie))
-
-        // Next request stringCookie2 will be all the way gone
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertCookie("cookie1", fooCookie)
-                                 .assertDoesNotContainsCookie("cookie2")
-                                 .assertCookie("fusionauth.sso", bazCookie))
-
-        // stringCookie1 and stringCookie3 holding strong after another request
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertCookie("cookie1", fooCookie)
-                                 .assertDoesNotContainsCookie("cookie2")
-                                 .assertCookie("fusionauth.sso", bazCookie))
-
-        // Delete all of them!!! - 1 and 3
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .withURLParameter("deleteCookie1", true)
-                                 .withURLParameter("deleteCookie3", true)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertCookieWasDeleted("cookie1")
-                                 .assertDoesNotContainsCookie("cookie2")
-                                 .assertCookieWasDeleted("fusionauth.sso"))
-
-        // They are now all gone.
-        .simulate(() -> simulator.test("/managed-cookie-scopes")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 .assertDoesNotContainsCookie("cookie1")
-                                 .assertDoesNotContainsCookie("cookie2")
-                                 .assertDoesNotContainsCookie("fusionauth.sso"));
-  }
-
-  @Test
-  public void uncompressed_unencrypted_contains_json() throws Exception {
-    // 1) The legacy cookie contains a value that can be parsed as JSON
-    // 2) The cookie is parsed, and the value is displayed as a JSON string
-    // 3) The cookie is rewritten in the modern format with a header
-    // 4) The follow-up request with the modern cookie still renders the JSON string
-    String value = "foo"; // `foo`
-    byte[] json = objectMapper.writeValueAsBytes(value); // `"foo"`
-    String jsonStr = new String(json, StandardCharsets.UTF_8);
-
-    // The first request is a modern, base64-encoded cookie with headers. The value is the JSON String `"foo"`
-    test.simulate(() -> simulator.test("/managed-cookie")
-                                 .withCookie("cookie", jsonStr)
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // `"foo"` is rendered
-                                 .assertBody(jsonStr)
-                                 // The new cookie is written in the modern format
-                                 .assertCookie("cookie", CookieTools.toCookie(json, false, false, encryptor)));
-
-    // The request works a second time with the updated cookie
-    test.simulate(() -> simulator.test("/managed-cookie")
-                                 .get()
-                                 .assertStatusCode(200)
-                                 // The cookie still contains `"foo"` after decoding
-                                 .assertBody(jsonStr)
-                                 // No change in the cookie value
-                                 .assertCookie("cookie", CookieTools.toCookie(json, false, false, encryptor)));
-  }
+        test.simulate(() -> simulator.test("/managed-cookie")
+                .get()
+                .assertStatusCode(200)
+                // The cookie still contains `"foo"` after decoding
+                .assertBody(jsonStr)
+                // No change in the cookie value
+                .assertCookie("cookie", CookieTools.toCookie(json, false, false, encryptor)));
+    }
 }

--- a/src/test/java/org/primeframework/mvc/test/RequestBuilder.java
+++ b/src/test/java/org/primeframework/mvc/test/RequestBuilder.java
@@ -15,35 +15,6 @@
  */
 package org.primeframework.mvc.test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpClient.Redirect;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublisher;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -54,8 +25,6 @@ import io.fusionauth.http.HTTPMethod;
 import io.fusionauth.http.HTTPValues.Headers;
 import io.fusionauth.http.server.HTTPRequest;
 import io.fusionauth.http.server.HTTPResponse;
-import io.fusionauth.jwks.domain.JSONWebKey;
-import io.fusionauth.jwt.Signer;
 import org.primeframework.mock.MockUserAgent;
 import org.primeframework.mvc.config.MVCConfiguration;
 import org.primeframework.mvc.http.FormBodyPublisher;
@@ -73,6 +42,27 @@ import org.primeframework.mvc.util.QueryStringBuilder;
 import org.primeframework.mvc.util.QueryStringTools;
 import org.primeframework.mvc.util.URITools;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublisher;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 /**
  * This class is a builder that helps create a test HTTP request that is sent to the MVC.
  *
@@ -80,976 +70,977 @@ import org.primeframework.mvc.util.URITools;
  */
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public class RequestBuilder {
-  public static HttpClient HttpClientInstance = newHttpClient();
+    public static HttpClient HttpClientInstance = newHttpClient();
 
-  public final Injector injector;
+    public final Injector injector;
 
-  public final TestMessageObserver messageObserver;
+    public final TestMessageObserver messageObserver;
 
-  public final int port;
+    public final int port;
 
-  public final HTTPRequest request;
+    public final HTTPRequest request;
 
-  public final Map<String, List<String>> requestBodyParameters = new LinkedHashMap<>();
+    public final Map<String, List<String>> requestBodyParameters = new LinkedHashMap<>();
 
-  public final MockUserAgent userAgent;
+    public final MockUserAgent userAgent;
 
-  public boolean useTLS;
+    public boolean useTLS;
 
-  private String bearerToken;
+    private String bearerToken;
 
-  private String dPoPToken;
+    private String dPoPToken;
 
-  private DPoPProofProvider dPoPProofProvider;
+    private DPoPProofProvider dPoPProofProvider;
 
-  private byte[] body;
+    private byte[] body;
 
-  @Inject(optional = true)
-  private HTTPRequestConsumer httpRequestConsumer;
+    @Inject(optional = true)
+    private HTTPRequestConsumer httpRequestConsumer;
 
-  public RequestBuilder(String path, Injector injector, MockUserAgent userAgent, TestMessageObserver messageObserver,
-                        int port) {
-    this.injector = injector;
-    this.userAgent = userAgent;
-    this.messageObserver = messageObserver;
-    this.request = new HTTPRequest().with(r -> r.setPath(path));
-    this.port = port;
-    //Injections optionally HTTPRequestConsumer
-    injector.injectMembers(this);
-  }
-
-  public static HttpClient newHttpClient() {
-    return HttpClient.newBuilder()
-                     // Setting this too low will cause TLS connections to timeout
-                     // - We used to set it to 0 in our own REST client, but 0 is not supported.
-                     // - 50 works fine for non TLS tests.
-                     .connectTimeout(Duration.ofMillis(250))
-                     // In theory this is faster. When switching to virtual threads in the load test framework I nearly doubled the RPS.
-                     // - However it is still way slower than RESTify which uses HTTPURLConnection. But that does have its own issues.
-                     .executor(Executors.newVirtualThreadPerTaskExecutor())
-                     .followRedirects(Redirect.NEVER)
-                     .build();
-  }
-
-  public static void resetHttpClientInstance() {
-    HttpClientInstance = newHttpClient();
-  }
-
-  /**
-   * Allows the builder to be passed to other code to add parameters and set things up.
-   *
-   * @param consumer The consumer of this request builder.
-   * @return This.
-   */
-  public RequestBuilder build(Consumer<RequestBuilder> consumer) {
-    consumer.accept(this);
-    return this;
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a CONNECT.
-   *
-   * @return The response.
-   */
-  public RequestResult connect() {
-    request.setMethod(HTTPMethod.CONNECT);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a DELETE.
-   *
-   * @return The response.
-   */
-  public RequestResult delete() {
-    request.setMethod(HTTPMethod.DELETE);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a GET.
-   *
-   * @return The response.
-   */
-  public RequestResult get() {
-    request.setMethod(HTTPMethod.GET);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  public HTTPRequest getRequest() {
-    return request;
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a HEAD.
-   *
-   * @return The response.
-   */
-  public RequestResult head() {
-    request.setMethod(HTTPMethod.HEAD);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * If the provided test is true invoke the <code>ifConsumer</code>, else.. you guessed it.
-   *
-   * @param test         the test
-   * @param ifConsumer   the consumer used if the test is true
-   * @param elseConsumer the consumer used if the test is false
-   * @return This.
-   */
-  public RequestBuilder ifElse(boolean test, ThrowingConsumer<RequestBuilder> ifConsumer,
-                               ThrowingConsumer<RequestBuilder> elseConsumer) throws Exception {
-    if (test) {
-      ifConsumer.accept(this);
-    } else {
-      elseConsumer.accept(this);
+    public RequestBuilder(String path, Injector injector, MockUserAgent userAgent, TestMessageObserver messageObserver,
+                          int port) {
+        this.injector = injector;
+        this.userAgent = userAgent;
+        this.messageObserver = messageObserver;
+        this.request = new HTTPRequest().with(r -> r.setPath(path));
+        this.port = port;
+        //Injections optionally HTTPRequestConsumer
+        injector.injectMembers(this);
     }
 
-    return this;
-  }
-
-  /**
-   * If the provided test is false invoke the consumer.
-   *
-   * @param test     the test
-   * @param consumer the consumer of this request builder
-   * @return This.
-   */
-  public RequestBuilder ifFalse(boolean test, ThrowingConsumer<RequestBuilder> consumer) throws Exception {
-    return ifTrue(!test, consumer);
-  }
-
-  /**
-   * If the provided test is true invoke the consumer.
-   *
-   * @param test     the test
-   * @param consumer the consumer of this request builder
-   * @return This.
-   */
-  public RequestBuilder ifTrue(boolean test, ThrowingConsumer<RequestBuilder> consumer) throws Exception {
-    if (test) {
-      consumer.accept(this);
+    public static HttpClient newHttpClient() {
+        return HttpClient.newBuilder()
+                // Setting this too low will cause TLS connections to timeout
+                // - We used to set it to 0 in our own REST client, but 0 is not supported.
+                // - 50 works fine for non TLS tests.
+                .connectTimeout(Duration.ofMillis(250))
+                // In theory this is faster. When switching to virtual threads in the load test framework I nearly doubled the RPS.
+                // - However it is still way slower than RESTify which uses HTTPURLConnection. But that does have its own issues.
+                .executor(Executors.newVirtualThreadPerTaskExecutor())
+                .followRedirects(Redirect.NEVER)
+                .build();
     }
 
-    return this;
-  }
-
-  /**
-   * Overrides the HTTP Method from that set by calling {@link #get()} or {@link #post()} for example.
-   *
-   * @param method the  HTTP method
-   * @return This.
-   */
-  public RequestResult method(HTTPMethod method) {
-    request.setMethod(method);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Overrides the HTTP Method from that set by calling {@link #get()} or {@link #post()} for example.
-   *
-   * @param method the string value of an HTTP method, this does not have to be a real HTTP method
-   * @return This.
-   */
-  public RequestResult method(String method) {
-    return method(HTTPMethod.of(method));
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a OPTIONS.
-   *
-   * @return The response.
-   */
-  public RequestResult options() {
-    request.setMethod(HTTPMethod.OPTIONS);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a PATCH.
-   *
-   * @return The response.
-   */
-  public RequestResult patch() {
-    request.setMethod(HTTPMethod.PATCH);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a POST.
-   *
-   * @return The response.
-   */
-  public RequestResult post() {
-    request.setMethod(HTTPMethod.POST);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a PUT.
-   *
-   * @return The response.
-   */
-  public RequestResult put() {
-    request.setMethod(HTTPMethod.PUT);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Provides the ability to set up the HTTPRequest object before making the request.
-   *
-   * @param consumer A consumer that takes the MutableHTTPRequest.
-   * @return This.
-   */
-  public RequestBuilder setup(Consumer<HTTPRequest> consumer) {
-    consumer.accept(request);
-    return this;
-  }
-
-  /**
-   * Sends the HTTP request to the MVC as a TRACE.
-   *
-   * @return The response.
-   */
-  public RequestResult trace() {
-    request.setMethod(HTTPMethod.TRACE);
-    HTTPResponseWrapper response = run();
-    return new RequestResult(injector, request, response, userAgent, messageObserver, port);
-  }
-
-  /**
-   * Sets the method as HTTPS and server port as 443.
-   *
-   * @return This.
-   */
-  public RequestBuilder usingHTTPS() {
-    throw new IllegalStateException("This handling is not implemented yet");
-  }
-
-  /**
-   * Adds an Authorization header to the request using the Bearer scheme with the specified encodedJWT.
-   * <p>Shorthand for calling
-   * <pre>
-   *   withHeader("Authorization", "Bearer " + encodedJWT)
-   * </pre>
-   *
-   * @param encodedJWT The Bearer token.
-   * @return This.
-   */
-  public RequestBuilder withAuthorizationBearerToken(String encodedJWT) {
-    if (dPoPToken != null) {
-      throw new IllegalStateException("Cannot set Authorization bearer token after setting DPoP token");
-    }
-    this.bearerToken = encodedJWT;
-    request.setHeader("Authorization", "Bearer " + encodedJWT);
-    return this;
-  }
-
-  /**
-   * Adds an Authorization header to the request using the DPoP scheme with the specified encodedJWT.
-   * Furthermore, the encodedJWT will be passed to the DPoPProofProvider.
-   *
-   * @param encodedJWT the DPoP bound access token
-   * @return This.
-   */
-  public RequestBuilder withAuthorizationDPoPToken(String encodedJWT) {
-    if (bearerToken != null) {
-      throw new IllegalStateException("Cannot set Authorization DPoP token after setting bearer token");
-    }
-    this.dPoPToken = encodedJWT;
-    request.setHeader("Authorization", "DPoP " + encodedJWT);
-    return this;
-  }
-
-  /**
-   * Adds an Authorization header to the request using the specified value.
-   * <p>Shorthand for calling
-   * <pre>
-   *   withHeader("Authorization", value)
-   * </pre>
-   *
-   * @param value The value of the <code>Authorization</code> header
-   * @return This.
-   */
-  public RequestBuilder withAuthorizationHeader(Object value) {
-    request.setHeader("Authorization", value.toString());
-    return this;
-  }
-
-  /**
-   * Adds a Basic Authorization header to the request using the specified value.
-   * <p>Shorthand for calling
-   * <pre>
-   *   String basic = username + (password != null ? ":" + password : "");
-   *   withHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes());)
-   * </pre>
-   *
-   * @param username The username used to build the basic authorization scheme
-   * @param password The password used to build the basic authorization scheme
-   * @return This.
-   */
-  public RequestBuilder withBasicAuthorizationHeader(String username, String password) {
-    String basic = username + (password != null ? ":" + password : "");
-    request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes()));
-    return this;
-  }
-
-  /**
-   * Sets the body content.
-   *
-   * @param bytes The bytes.
-   * @return This.
-   */
-  public RequestBuilder withBody(byte[] bytes) {
-    this.body = bytes;
-    return this;
-  }
-
-  /**
-   * Sets the body content.
-   *
-   * @param body The body as a String.
-   * @return This.
-   */
-  public RequestBuilder withBody(String body) {
-    return withBody(body.getBytes(StandardCharsets.UTF_8));
-  }
-
-  /**
-   * Sets the body content. This processes the file using FreeMarker. Use {@link #withBodyFileRaw(Path)} to skip FreeMarker processing.
-   *
-   * @param body   The body as a {@link Path} to the file.
-   * @param values key value pairs of replacement values for use in the file.
-   * @return This.
-   * @throws IOException If the file could not be loaded.
-   */
-  public RequestBuilder withBodyFile(Path body, Object... values) throws IOException {
-    return withBody(BodyTools.processTemplate(body, values));
-  }
-
-  /**
-   * Sets the body content.
-   *
-   * @param body The body as a {@link Path} to the raw file.
-   * @return This.
-   * @throws IOException If the file could not be loaded.
-   */
-  public RequestBuilder withBodyFileRaw(Path body) throws IOException {
-    return withBody(Files.readAllBytes(body));
-  }
-
-  /**
-   * Adds a CSRF token to the request parameters.
-   *
-   * @param token The token.
-   * @return This.
-   */
-  public RequestBuilder withCSRFToken(String token) {
-    String parameterName = injector.getInstance(CSRFProvider.class).getParameterName();
-    request.addURLParameter(parameterName, token);
-    return this;
-  }
-
-  /**
-   * Sets an HTTP request body parameter as a Prime MVC checkbox widget. This can be called multiple times with the same name, and it will create a
-   * list of values for the HTTP parameter.
-   *
-   * @param name           The name of the parameter.
-   * @param checkedValue   The checked value of the checkbox.
-   * @param uncheckedValue The checked value of the checkbox.
-   * @param checked        If the checkbox is checked.
-   * @return This.
-   */
-  public RequestBuilder withCheckbox(String name, String checkedValue, String uncheckedValue, boolean checked) {
-    if (checked) {
-      withParameter(name, checkedValue);
+    public static void resetHttpClientInstance() {
+        HttpClientInstance = newHttpClient();
     }
 
-    withParameter(DefaultParameterParser.CHECKBOX_PREFIX + name, uncheckedValue);
-    return this;
-  }
-
-  /**
-   * Sets the content type.
-   *
-   * @param contentType The content type.
-   * @return This.
-   */
-  public RequestBuilder withContentType(String contentType) {
-    request.setContentType(contentType);
-    return this;
-  }
-
-  /**
-   * Sets the context path.
-   *
-   * @param contextPath The context path.
-   * @return This.
-   */
-  public RequestBuilder withContextPath(String contextPath) {
-    request.setContextPath(contextPath);
-    return this;
-  }
-
-  /**
-   * Add a cookie to the request that is optionally compressed and/or encrypted.
-   *
-   * @param name     The name of the cookie.
-   * @param value    The plaintext value of the cookie.
-   * @param compress Whether to compress the cookie.
-   * @param encrypt  Whether to encrypt the cookie.
-   * @return This.
-   */
-  public RequestBuilder withCookie(String name, String value, boolean compress, boolean encrypt) throws Exception {
-    if (name != null) {
-      Cookie cookie;
-      if ((compress || encrypt) && value != null) {
-        cookie = new Cookie(name, CookieTools.toCookie(value.getBytes(StandardCharsets.UTF_8), compress, encrypt, injector.getInstance(Encryptor.class)));
-      } else {
-        cookie = new Cookie(name, value);
-      }
-      request.addCookies(cookie);
-    }
-    return this;
-  }
-
-  /**
-   * Add a plaintext cookie to the request.
-   *
-   * @param name  The name of the cookie.
-   * @param value The value of the cookie.
-   * @return This.
-   */
-  public RequestBuilder withCookie(String name, String value) throws Exception {
-    return withCookie(name, value, false, false);
-  }
-
-  /**
-   * Provide a DPoPProofProvider to be used for adding a DPoP proof header to the request.
-   * An HTTP header will be added with name DPoP and value of what
-   * dPoPProofProvider.generateDPoPProof() returns.
-   *
-   * @param dPoPProofProvider an implementation of DPoPProofProvider
-   * @return This.
-   */
-  public RequestBuilder withDPoPProofProvider(DPoPProofProvider dPoPProofProvider) {
-    this.dPoPProofProvider = dPoPProofProvider;
-    return this;
-  }
-
-  /**
-   * Add a cookie to the request.
-   *
-   * @param cookie The cookie.
-   * @return This.
-   */
-  public RequestBuilder withCookie(Cookie cookie) {
-    if (cookie != null) {
-      request.addCookies(cookie);
-    }
-    return this;
-  }
-
-  /**
-   * Sets the encoding.
-   *
-   * @param encoding The encoding.
-   * @return This.
-   */
-  public RequestBuilder withEncoding(Charset encoding) {
-    request.setCharacterEncoding(encoding);
-    return this;
-  }
-
-  /**
-   * Encrypt the provided value and add a cookie with the encrypted value to the request
-   *
-   * @param name  The name of the cookie.
-   * @param value The unencrypted value of the cookie.
-   * @return This.
-   */
-  public RequestBuilder withEncryptedCookie(String name, String value) throws Exception {
-    return withCookie(name, value, false, true);
-  }
-
-  /**
-   * Adds a file.
-   *
-   * @param name        The name of the file form field.
-   * @param file        The file.
-   * @param contentType The content type.
-   * @return This.
-   */
-  public RequestBuilder withFile(String name, Path file, String contentType) {
-    request.getFiles().add(new FileInfo(file, null, name, contentType, StandardCharsets.UTF_8));
-    return this;
-  }
-
-  /**
-   * Adds a header to the request.
-   *
-   * @param name  The name of the header.
-   * @param value The value of the header.
-   * @return This.
-   */
-  public RequestBuilder withHeader(String name, Object value) {
-    request.addHeader(name, value.toString());
-    return this;
-  }
-
-  /**
-   * Uses the given object as the JSON body for the request with the {@code application/json} content type. This object is converted into JSON using
-   * Jackson.
-   *
-   * @param object The object to send in the request.
-   * @return This.
-   * @throws JsonProcessingException If the Jackson marshalling failed.
-   */
-  public RequestBuilder withJSON(Object object) throws JsonProcessingException {
-    return withJSON("application/json", object);
-  }
-
-  /**
-   * Uses the given object as the JSON body for the request with the given content type. This object is converted into JSON using Jackson.
-   *
-   * @param contentType The Content-Type header value
-   * @param object      The object to send in the request.
-   * @return This.
-   * @throws JsonProcessingException If the Jackson marshalling failed.
-   */
-  public RequestBuilder withJSON(String contentType, Object object) throws JsonProcessingException {
-    ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
-    byte[] json = objectMapper.writeValueAsBytes(object);
-    return withContentType(contentType).withBody(json);
-  }
-
-  /**
-   * Uses the given string as the JSON body for the request with the {@code application/json} content type.
-   *
-   * @param json The string representation of the JSON to send in the request.
-   * @return This.
-   */
-  public RequestBuilder withJSON(String json) {
-    return withJSON("application/json", json);
-  }
-
-  /**
-   * Uses the given string as the JSON body for the request with the given content type.
-   *
-   * @param contentType The Content-Type header value
-   * @param json        The string representation of the JSON to send in the request.
-   * @return This.
-   */
-  public RequestBuilder withJSON(String contentType, String json) {
-    return withContentType(contentType).withBody(json);
-  }
-
-  /**
-   * Applies the given consumer to build a JSON body for the request with the {@code application/json} content type.
-   *
-   * @param consumer The {@link JSONBuilder} consumer to build request
-   * @return This.
-   * @throws Exception If the Jackson marshalling failed or consumer threw an exception.
-   */
-  public RequestBuilder withJSONBuilder(ThrowingConsumer<JSONBuilder> consumer) throws Exception {
-    return withJSONBuilder("application/json", consumer);
-  }
-
-  /**
-   * Applies the given consumer to build a JSON body for the request with the given content type.
-   *
-   * @param contentType The Content-Type header value
-   * @param consumer    The {@link JSONBuilder} consumer to build request
-   * @return This.
-   * @throws Exception If the Jackson marshalling failed or consumer threw an exception.
-   */
-  public RequestBuilder withJSONBuilder(String contentType, ThrowingConsumer<JSONBuilder> consumer) throws Exception {
-    ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
-    JSONBuilder builder = new JSONBuilder(objectMapper);
-    consumer.accept(builder);
-    withJSON(contentType, builder.build());
-    return this;
-  }
-
-  /**
-   * Uses the given {@link Path} object to a JSON file as the JSON body for the request with the {@code application/json} content type.
-   *
-   * @param jsonFile The string representation of the JSON to send in the request.
-   * @param values   key value pairs of replacement values for use in the JSON file.
-   * @return This.
-   * @throws IOException If the file could not be loaded.
-   */
-  public RequestBuilder withJSONFile(Path jsonFile, Object... values)
-      throws IOException {
-    return withJSONFile("application/json", jsonFile, values);
-  }
-
-  /**
-   * Uses the given {@link Path} object to a JSON file as the JSON body for the request with the given content type.
-   *
-   * @param contentType The Content-Type header value
-   * @param jsonFile    The string representation of the JSON to send in the request.
-   * @param values      key value pairs of replacement values for use in the JSON file.
-   * @return This.
-   * @throws IOException If the file could not be loaded.
-   */
-  public RequestBuilder withJSONFile(String contentType, Path jsonFile, Object... values)
-      throws IOException {
-    return withContentType(contentType).withBodyFile(jsonFile, values);
-  }
-
-  /**
-   * Sets the locale that will be used.
-   *
-   * @param locale The locale.
-   * @return This.
-   */
-  public RequestBuilder withLocale(Locale locale) {
-    request.addLocales(locale);
-    return this;
-  }
-
-  /**
-   * Sets an HTTP request body parameter. This can be called multiple times with the same name it will create a list of values for the HTTP
-   * parameter.
-   *
-   * @param name  The name of the parameter.
-   * @param value The parameter value. This is an object so toString is called on it to convert it to a String.
-   * @return This.
-   */
-  public RequestBuilder withParameter(String name, Object value) {
-    requestBodyParameters.computeIfAbsent(name, key -> new ArrayList<>()).add(value != null ? value.toString() : null);
-    return this;
-  }
-
-  /**
-   * Sets HTTP request body parameters. This takes the provided collection and adds a request parameter for each item in the collection.
-   *
-   * @param name   The name of the parameter.
-   * @param values The collection of parameter values.
-   * @return This.
-   */
-  public RequestBuilder withParameters(String name, Collection<?> values) {
-    requestBodyParameters.computeIfAbsent(name, key -> new ArrayList<>()).addAll(values.stream().map(Object::toString).toList());
-    return this;
-  }
-
-  /**
-   * Sets HTTP request parameters from a query String that is already encoded and might contain multiple parameters. This will split the parameters up
-   * and decode them.
-   *
-   * @param query The query string.
-   * @return This.
-   */
-  public RequestBuilder withQueryString(String query) {
-    QueryStringTools.parseQueryString(query).forEach(this::withURLParameters);
-    return this;
-  }
-
-  /**
-   * Sets an HTTP request body parameter as a Prime MVC radio button widget. This can be called multiple times with the same name it will create a
-   * list of values for the HTTP parameter.
-   *
-   * @param name           The name of the parameter.
-   * @param checkedValue   The checked value of the checkbox.
-   * @param uncheckedValue The checked value of the checkbox.
-   * @param checked        If the checkbox is checked.
-   * @return This.
-   */
-  public RequestBuilder withRadio(String name, String checkedValue, String uncheckedValue, boolean checked) {
-    if (checked) {
-      setRequestBodyParameter(name, checkedValue);
-    }
-
-    setRequestBodyParameter(DefaultParameterParser.RADIOBUTTON_PREFIX + name, uncheckedValue);
-    return this;
-  }
-
-  /**
-   * Add a single request header. Calling this sequentially will just overwrite the previous value. If you wish to add a header multiple times, use
-   * {@link #withHeader(String, Object)} instead.
-   *
-   * @param name  The name of the header.
-   * @param value The value of the header.
-   * @return This.
-   */
-  public RequestBuilder withSingleHeader(String name, String value) {
-    request.setHeader(name, value);
-    return this;
-  }
-
-  /**
-   * Adds a header to the request only if the value is non-null. If the value is null, this method is a no-op.
-   * Follows the same pattern as {@link #withSingleHeader(String, String)}, it will replace if called sequentially
-   *
-   * @param name  The name of the header.
-   * @param value The value of the header, or {@code null} to skip adding the header.
-   * @return This.
-   */
-  public RequestBuilder withHeaderIfPresent(String name, String value) {
-    if (value != null) {
-      request.setHeader(name, value);
-    }
-    return this;
-  }
-
-  /**
-   * Add a single URL query string parameter.
-   *
-   * @param name  the name of the parameter.
-   * @param value the value of the parameter.
-   * @return This.
-   */
-  public RequestBuilder withURLParameter(String name, Object value) {
-    request.addURLParameter(name, value.toString());
-    return this;
-  }
-
-  /**
-   * Add all URL query string parameters.
-   *
-   * @param name   the name of the parameter.
-   * @param values The collection of parameter values.
-   * @return This.
-   */
-  public RequestBuilder withURLParameters(String name, Collection<?> values) {
-    request.addURLParameters(name, values.stream().map(Object::toString).collect(Collectors.toList()));
-    return this;
-  }
-
-  /**
-   * Append a url path segment to the current request URI.
-   * <p>
-   * For Example:
-   * <pre>
-   *   .simulator.test("/user/delete")
-   *             .withUrlSegment("bar")
-   *   </pre>
-   * This will result in a url of <code>/user/delete/bar</code>, this is equivalent to the following code:
-   * <pre>
-   *   .simulator.test("/user/delete/" + "bar")
-   *   </pre>
-   *
-   * @param value The url path segment. A null value will be ignored.
-   * @return This.
-   */
-  public RequestBuilder withURLSegment(Object value) {
-    if (value != null) {
-      String uri = request.getPath();
-      if (uri.charAt(uri.length() - 1) != '/') {
-        uri += '/';
-      }
-
-      request.setPath(uri + URITools.encodeURIPathSegment(value));
-    }
-
-    return this;
-  }
-
-  /**
-   * Bad name, use the correct URL method.
-   *
-   * @deprecated
-   */
-  @Deprecated
-  public RequestBuilder withUrlSegment(Object value) {
-    return withURLSegment(value);
-  }
-
-  HTTPResponseWrapper run() {
-    // Set the new request & response so that we can inject things below
-    HTTPObjectsHolder.clearRequest();
-    HTTPObjectsHolder.setRequest(request);
-    HTTPObjectsHolder.clearResponse();
-    HTTPObjectsHolder.setResponse(new HTTPResponse());
-
-    // Add a unique Id so that we can identify messages for this request in the observer.
-    String messageStoreId = UUID.randomUUID().toString();
-    messageObserver.setMessageStoreId(messageStoreId);
-    request.addHeader(TestMessageObserver.ObserverMessageStoreId, messageStoreId);
-
-    // New cookies were added to the request and not the user-agent, so we need to sync them to the user-agent here.
-    // Then we can add all cookies form the user-agent to the request.
-    userAgent.addCookies(request.getCookies());
-    request.getCookies().clear();
-    request.addCookies(userAgent.getCookies(request));
-
-    String scheme = useTLS ? "https://" : "http://";
-    URI requestURI = URI.create(scheme + "localhost:" + port + request.getPath());
-
-    // Referer for CSRF checks must be provided
-    if (request.getHeader("Referer") == null) {
-      request.setHeader("Referer", requestURI.toString());
-    }
-
-    request.setPort(port);
-    request.setHost(requestURI.getHost());
-    request.setScheme(requestURI.getScheme());
-
-    if (dPoPProofProvider != null) {
-      request.addHeader("DPoP", dPoPProofProvider.generateDPoPProof(request.getMethod(), requestURI.toString(), this.dPoPToken));
-    }
-
-    // Now that the cookies are ready, if the CSRF token is enabled and the parameter isn't set, we set it to be consistent
-    // since the [@control.form] would normally set that into the form and into the request.
-    if (request.getMethod() == HTTPMethod.POST) {
-      MVCConfiguration configuration = injector.getInstance(MVCConfiguration.class);
-      if (configuration.csrfEnabled()) {
-        CSRFProvider csrfProvider = injector.getInstance(CSRFProvider.class);
-        if (csrfProvider.getTokenFromRequest(request) == null) {
-          String token = csrfProvider.getToken(request);
-          if (token != null) {
-            String parameterName = csrfProvider.getParameterName();
-            requestBodyParameters.put(parameterName, List.of(token));
-          }
-        }
-      }
-    }
-
-    // Allow the caller to consume the HTTP request in order to mutate it and what not.
-    if (httpRequestConsumer != null) {
-      httpRequestConsumer.accept(request);
-    }
-
-    List<Locale> locales = request.getLocales();
-    String contentType = request.getContentType();
-    Charset characterEncoding = request.getCharacterEncoding();
-    HTTPMethod method = request.getMethod();
-
-    Map<String, List<String>> urlParameters = request.getParameters();
-    List<FileInfo> files = request.getFiles();
-    BodyPublisher bodyPublisher = BodyPublishers.noBody();
-    // We'll use this to keep the java-http HTTP Request in sync
-    InputStream inputStream = null;
-
-    if (files != null && !files.isEmpty()) {
-      List<MultipartFileUpload> fileUploads = files.stream()
-                                                   .map(fi -> new MultipartFileUpload(fi.contentType, fi.file, fi.fileName, fi.name))
-                                                   .collect(Collectors.toList());
-      MultipartBodyHandler multipartBodyHandler = new MultipartBodyHandler(new Multiparts(fileUploads, requestBodyParameters));
-      bodyPublisher = BodyPublishers.ofByteArray(multipartBodyHandler.getBody());
-      if (contentType == null) {
-        contentType = "multipart/form-data; boundary=" + multipartBodyHandler.boundary;
-      }
-      inputStream = new ByteArrayInputStream(multipartBodyHandler.getBody());
-    } else if (body != null) {
-      bodyPublisher = BodyPublishers.ofByteArray(body);
-      inputStream = new ByteArrayInputStream(body);
-    } else if (!requestBodyParameters.isEmpty()) {
-      byte[] formBody = new FormBodyPublisher(requestBodyParameters).getBody();
-      bodyPublisher = BodyPublishers.ofByteArray(formBody);
-      if (contentType == null) {
-        contentType = "application/x-www-form-urlencoded";
-      }
-      inputStream = (new ByteArrayInputStream(formBody));
-    }
-
-    // Keep this HTTP request in sync so that we can optionally use it in various test use cases.
-    if (inputStream != null) {
-      request.setInputStream(inputStream);
-    }
-
-    var requestBuilder = HttpRequest.newBuilder()
-                                    .method(request.getMethod().name(), bodyPublisher);
-
-    if (locales.isEmpty()) {
-      // request.getLocale() returns a default locale if none are set by httpRequestConsumer but
-      // we still want to set to the system's default, if none were explicitly set.
-      locales = List.of(Locale.getDefault());
-    }
-    requestBuilder.setHeader("Accept-Language", locales.stream().map(Locale::toLanguageTag).collect(Collectors.joining(", ")));
-
-    if (contentType != null) {
-      requestBuilder.setHeader(Headers.ContentType, contentType + (characterEncoding != null ? "; charset=" + characterEncoding : ""));
-
-      // Keep this HTTP request in sync so that we can optionally use it in various test use cases.
-      request.setContentType(contentType);
-    }
-
-    // Copy over headers
-    request.getHeaders().forEach((name, values) ->
-                                     values.forEach(value -> requestBuilder.header(name, value)));
-
-    // Set cookies
-    if (request.getHeaders().keySet().stream().noneMatch(name -> name.equalsIgnoreCase(Headers.Cookie)) && !request.getCookies().isEmpty()) {
-      String header = request.getCookies()
-                             .stream()
-                             .map(io.fusionauth.http.Cookie::toRequestHeader)
-                             .collect(Collectors.joining("; "));
-      requestBuilder.setHeader(Headers.Cookie, header);
-    }
-
-    // Set the UserAgent header if not already set
-    // - Do this because the default UserAgent string will include the Java version string which is annoying to update in tests.
-    if (request.getHeaders().keySet().stream().noneMatch(name -> name.equalsIgnoreCase(Headers.UserAgent))) {
-      requestBuilder.setHeader(Headers.UserAgent, "Java HttpClient");
-    }
-
-    QueryStringBuilder queryStringBuilder = QueryStringBuilder.builder();
-    urlParameters.forEach((name, values) -> values.forEach(value -> queryStringBuilder.with(name, value)));
-
-    URI fullURI = urlParameters.isEmpty()
-        ? requestURI
-        : URI.create(requestURI + "?" + queryStringBuilder.build());
-
-    requestBuilder.uri(fullURI);
-
-    HTTPResponseWrapper result = new HTTPResponseWrapper();
-    try {
-      result.response = HttpClientInstance.send(requestBuilder.build(),
-                                                BodyHandlers.ofByteArray());
-    } catch (Exception e) {
-      result.exception = e;
-      result.init();
-      return result;
-    }
-
-    // Extract the cookies and put them in the UserAgent
-    userAgent.addCookies(getCookies(result.response)
-                             .stream()
-                             .map(c -> new Cookie().with(c1 -> c1.domain = c.domain)
-                                                   .with(c1 -> c1.expires = c.expires)
-                                                   .with(c1 -> c1.httpOnly = c.httpOnly)
-                                                   .with(c1 -> c1.maxAge = c.maxAge)
-                                                   .with(c1 -> c1.name = c.name)
-                                                   .with(c1 -> c1.path = c.path)
-                                                   .with(c1 -> c1.sameSite = c.sameSite != null ? Cookie.SameSite.valueOf(c.sameSite.name()) : null)
-                                                   .with(c1 -> c1.secure = c.secure).with(c1 -> c1.value = c.value))
-                             .collect(Collectors.toList()));
-
-    result.init();
-    return result;
-  }
-
-  private List<io.fusionauth.http.Cookie> getCookies(HttpResponse<byte[]> response) {
-    List<String> cookies = response.headers().allValues(Headers.SetCookie.toLowerCase());
-    if (cookies != null && !cookies.isEmpty()) {
-      return cookies.stream().map(io.fusionauth.http.Cookie::fromResponseHeader).filter(Objects::nonNull).collect(Collectors.toList());
-    }
-
-    return List.of();
-  }
-
-  private void setRequestBodyParameter(String name, Object value) {
-    List<String> values = new ArrayList<>();
-    values.add(value.toString());
-    requestBodyParameters.put(name, values);
-  }
-
-  public interface HTTPRequestConsumer {
     /**
-     * @param httpRequest the http request
+     * Allows the builder to be passed to other code to add parameters and set things up.
+     *
+     * @param consumer The consumer of this request builder.
+     * @return This.
      */
-    void accept(HTTPRequest httpRequest);
-  }
+    public RequestBuilder build(Consumer<RequestBuilder> consumer) {
+        consumer.accept(this);
+        return this;
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a CONNECT.
+     *
+     * @return The response.
+     */
+    public RequestResult connect() {
+        request.setMethod(HTTPMethod.CONNECT);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a DELETE.
+     *
+     * @return The response.
+     */
+    public RequestResult delete() {
+        request.setMethod(HTTPMethod.DELETE);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a GET.
+     *
+     * @return The response.
+     */
+    public RequestResult get() {
+        request.setMethod(HTTPMethod.GET);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    public HTTPRequest getRequest() {
+        return request;
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a HEAD.
+     *
+     * @return The response.
+     */
+    public RequestResult head() {
+        request.setMethod(HTTPMethod.HEAD);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * If the provided test is true invoke the <code>ifConsumer</code>, else.. you guessed it.
+     *
+     * @param test         the test
+     * @param ifConsumer   the consumer used if the test is true
+     * @param elseConsumer the consumer used if the test is false
+     * @return This.
+     */
+    public RequestBuilder ifElse(boolean test, ThrowingConsumer<RequestBuilder> ifConsumer,
+                                 ThrowingConsumer<RequestBuilder> elseConsumer) throws Exception {
+        if (test) {
+            ifConsumer.accept(this);
+        } else {
+            elseConsumer.accept(this);
+        }
+
+        return this;
+    }
+
+    /**
+     * If the provided test is false invoke the consumer.
+     *
+     * @param test     the test
+     * @param consumer the consumer of this request builder
+     * @return This.
+     */
+    public RequestBuilder ifFalse(boolean test, ThrowingConsumer<RequestBuilder> consumer) throws Exception {
+        return ifTrue(!test, consumer);
+    }
+
+    /**
+     * If the provided test is true invoke the consumer.
+     *
+     * @param test     the test
+     * @param consumer the consumer of this request builder
+     * @return This.
+     */
+    public RequestBuilder ifTrue(boolean test, ThrowingConsumer<RequestBuilder> consumer) throws Exception {
+        if (test) {
+            consumer.accept(this);
+        }
+
+        return this;
+    }
+
+    /**
+     * Overrides the HTTP Method from that set by calling {@link #get()} or {@link #post()} for example.
+     *
+     * @param method the  HTTP method
+     * @return This.
+     */
+    public RequestResult method(HTTPMethod method) {
+        request.setMethod(method);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Overrides the HTTP Method from that set by calling {@link #get()} or {@link #post()} for example.
+     *
+     * @param method the string value of an HTTP method, this does not have to be a real HTTP method
+     * @return This.
+     */
+    public RequestResult method(String method) {
+        return method(HTTPMethod.of(method));
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a OPTIONS.
+     *
+     * @return The response.
+     */
+    public RequestResult options() {
+        request.setMethod(HTTPMethod.OPTIONS);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a PATCH.
+     *
+     * @return The response.
+     */
+    public RequestResult patch() {
+        request.setMethod(HTTPMethod.PATCH);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a POST.
+     *
+     * @return The response.
+     */
+    public RequestResult post() {
+        request.setMethod(HTTPMethod.POST);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a PUT.
+     *
+     * @return The response.
+     */
+    public RequestResult put() {
+        request.setMethod(HTTPMethod.PUT);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Provides the ability to set up the HTTPRequest object before making the request.
+     *
+     * @param consumer A consumer that takes the MutableHTTPRequest.
+     * @return This.
+     */
+    public RequestBuilder setup(Consumer<HTTPRequest> consumer) {
+        consumer.accept(request);
+        return this;
+    }
+
+    /**
+     * Sends the HTTP request to the MVC as a TRACE.
+     *
+     * @return The response.
+     */
+    public RequestResult trace() {
+        request.setMethod(HTTPMethod.TRACE);
+        HTTPResponseWrapper response = run();
+        return new RequestResult(injector, request, response, userAgent, messageObserver, port);
+    }
+
+    /**
+     * Sets the method as HTTPS and server port as 443.
+     *
+     * @return This.
+     */
+    public RequestBuilder usingHTTPS() {
+        throw new IllegalStateException("This handling is not implemented yet");
+    }
+
+    /**
+     * Adds an Authorization header to the request using the Bearer scheme with the specified encodedJWT.
+     * <p>Shorthand for calling
+     * <pre>
+     *   withHeader("Authorization", "Bearer " + encodedJWT)
+     * </pre>
+     *
+     * @param encodedJWT The Bearer token.
+     * @return This.
+     */
+    public RequestBuilder withAuthorizationBearerToken(String encodedJWT) {
+        if (dPoPToken != null) {
+            throw new IllegalStateException("Cannot set Authorization bearer token after setting DPoP token");
+        }
+        this.bearerToken = encodedJWT;
+        request.setHeader("Authorization", "Bearer " + encodedJWT);
+        return this;
+    }
+
+    /**
+     * Adds an Authorization header to the request using the DPoP scheme with the specified encodedJWT.
+     * Furthermore, the encodedJWT will be passed to the DPoPProofProvider.
+     *
+     * @param encodedJWT the DPoP bound access token
+     * @return This.
+     */
+    public RequestBuilder withAuthorizationDPoPToken(String encodedJWT) {
+        if (bearerToken != null) {
+            throw new IllegalStateException("Cannot set Authorization DPoP token after setting bearer token");
+        }
+        this.dPoPToken = encodedJWT;
+        request.setHeader("Authorization", "DPoP " + encodedJWT);
+        return this;
+    }
+
+    /**
+     * Adds an Authorization header to the request using the specified value.
+     * <p>Shorthand for calling
+     * <pre>
+     *   withHeader("Authorization", value)
+     * </pre>
+     *
+     * @param value The value of the <code>Authorization</code> header
+     * @return This.
+     */
+    public RequestBuilder withAuthorizationHeader(Object value) {
+        request.setHeader("Authorization", value.toString());
+        return this;
+    }
+
+    /**
+     * Adds a Basic Authorization header to the request using the specified value.
+     * <p>Shorthand for calling
+     * <pre>
+     *   String basic = username + (password != null ? ":" + password : "");
+     *   withHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes());)
+     * </pre>
+     *
+     * @param username The username used to build the basic authorization scheme
+     * @param password The password used to build the basic authorization scheme
+     * @return This.
+     */
+    public RequestBuilder withBasicAuthorizationHeader(String username, String password) {
+        String basic = username + (password != null ? ":" + password : "");
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(basic.getBytes()));
+        return this;
+    }
+
+    /**
+     * Sets the body content.
+     *
+     * @param bytes The bytes.
+     * @return This.
+     */
+    public RequestBuilder withBody(byte[] bytes) {
+        this.body = bytes;
+        return this;
+    }
+
+    /**
+     * Sets the body content.
+     *
+     * @param body The body as a String.
+     * @return This.
+     */
+    public RequestBuilder withBody(String body) {
+        return withBody(body.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Sets the body content. This processes the file using FreeMarker. Use {@link #withBodyFileRaw(Path)} to skip FreeMarker processing.
+     *
+     * @param body   The body as a {@link Path} to the file.
+     * @param values key value pairs of replacement values for use in the file.
+     * @return This.
+     * @throws IOException If the file could not be loaded.
+     */
+    public RequestBuilder withBodyFile(Path body, Object... values) throws IOException {
+        return withBody(BodyTools.processTemplate(body, values));
+    }
+
+    /**
+     * Sets the body content.
+     *
+     * @param body The body as a {@link Path} to the raw file.
+     * @return This.
+     * @throws IOException If the file could not be loaded.
+     */
+    public RequestBuilder withBodyFileRaw(Path body) throws IOException {
+        return withBody(Files.readAllBytes(body));
+    }
+
+    /**
+     * Adds a CSRF token to the request parameters.
+     *
+     * @param token The token.
+     * @return This.
+     */
+    public RequestBuilder withCSRFToken(String token) {
+        String parameterName = injector.getInstance(CSRFProvider.class).getParameterName();
+        request.addURLParameter(parameterName, token);
+        return this;
+    }
+
+    /**
+     * Sets an HTTP request body parameter as a Prime MVC checkbox widget. This can be called multiple times with the same name, and it will create a
+     * list of values for the HTTP parameter.
+     *
+     * @param name           The name of the parameter.
+     * @param checkedValue   The checked value of the checkbox.
+     * @param uncheckedValue The checked value of the checkbox.
+     * @param checked        If the checkbox is checked.
+     * @return This.
+     */
+    public RequestBuilder withCheckbox(String name, String checkedValue, String uncheckedValue, boolean checked) {
+        if (checked) {
+            withParameter(name, checkedValue);
+        }
+
+        withParameter(DefaultParameterParser.CHECKBOX_PREFIX + name, uncheckedValue);
+        return this;
+    }
+
+    /**
+     * Sets the content type.
+     *
+     * @param contentType The content type.
+     * @return This.
+     */
+    public RequestBuilder withContentType(String contentType) {
+        request.setContentType(contentType);
+        return this;
+    }
+
+    /**
+     * Sets the context path.
+     *
+     * @param contextPath The context path.
+     * @return This.
+     */
+    public RequestBuilder withContextPath(String contextPath) {
+        request.setContextPath(contextPath);
+        return this;
+    }
+
+    /**
+     * Add a cookie to the request that is optionally compressed and/or encrypted.
+     *
+     * @param name     The name of the cookie.
+     * @param value    The plaintext value of the cookie.
+     * @param compress Whether to compress the cookie.
+     * @param encrypt  Whether to encrypt the cookie.
+     * @return This.
+     */
+    public RequestBuilder withCookie(String name, String value, boolean compress, boolean encrypt) throws Exception {
+        if (name != null) {
+            Cookie cookie;
+            // we always want to put our header on, even if not encrypting/decrypting
+            if (value != null) {
+                cookie = new Cookie(name, CookieTools.toCookie(value.getBytes(StandardCharsets.UTF_8), compress, encrypt, injector.getInstance(Encryptor.class)));
+            } else {
+                cookie = new Cookie(name, value);
+            }
+            request.addCookies(cookie);
+        }
+        return this;
+    }
+
+    /**
+     * Add a plaintext cookie to the request.
+     *
+     * @param name  The name of the cookie.
+     * @param value The value of the cookie.
+     * @return This.
+     */
+    public RequestBuilder withCookie(String name, String value) throws Exception {
+        return withCookie(name, value, false, false);
+    }
+
+    /**
+     * Provide a DPoPProofProvider to be used for adding a DPoP proof header to the request.
+     * An HTTP header will be added with name DPoP and value of what
+     * dPoPProofProvider.generateDPoPProof() returns.
+     *
+     * @param dPoPProofProvider an implementation of DPoPProofProvider
+     * @return This.
+     */
+    public RequestBuilder withDPoPProofProvider(DPoPProofProvider dPoPProofProvider) {
+        this.dPoPProofProvider = dPoPProofProvider;
+        return this;
+    }
+
+    /**
+     * Add a cookie to the request.
+     *
+     * @param cookie The cookie.
+     * @return This.
+     */
+    public RequestBuilder withCookie(Cookie cookie) {
+        if (cookie != null) {
+            request.addCookies(cookie);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the encoding.
+     *
+     * @param encoding The encoding.
+     * @return This.
+     */
+    public RequestBuilder withEncoding(Charset encoding) {
+        request.setCharacterEncoding(encoding);
+        return this;
+    }
+
+    /**
+     * Encrypt the provided value and add a cookie with the encrypted value to the request
+     *
+     * @param name  The name of the cookie.
+     * @param value The unencrypted value of the cookie.
+     * @return This.
+     */
+    public RequestBuilder withEncryptedCookie(String name, String value) throws Exception {
+        return withCookie(name, value, false, true);
+    }
+
+    /**
+     * Adds a file.
+     *
+     * @param name        The name of the file form field.
+     * @param file        The file.
+     * @param contentType The content type.
+     * @return This.
+     */
+    public RequestBuilder withFile(String name, Path file, String contentType) {
+        request.getFiles().add(new FileInfo(file, null, name, contentType, StandardCharsets.UTF_8));
+        return this;
+    }
+
+    /**
+     * Adds a header to the request.
+     *
+     * @param name  The name of the header.
+     * @param value The value of the header.
+     * @return This.
+     */
+    public RequestBuilder withHeader(String name, Object value) {
+        request.addHeader(name, value.toString());
+        return this;
+    }
+
+    /**
+     * Uses the given object as the JSON body for the request with the {@code application/json} content type. This object is converted into JSON using
+     * Jackson.
+     *
+     * @param object The object to send in the request.
+     * @return This.
+     * @throws JsonProcessingException If the Jackson marshalling failed.
+     */
+    public RequestBuilder withJSON(Object object) throws JsonProcessingException {
+        return withJSON("application/json", object);
+    }
+
+    /**
+     * Uses the given object as the JSON body for the request with the given content type. This object is converted into JSON using Jackson.
+     *
+     * @param contentType The Content-Type header value
+     * @param object      The object to send in the request.
+     * @return This.
+     * @throws JsonProcessingException If the Jackson marshalling failed.
+     */
+    public RequestBuilder withJSON(String contentType, Object object) throws JsonProcessingException {
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+        byte[] json = objectMapper.writeValueAsBytes(object);
+        return withContentType(contentType).withBody(json);
+    }
+
+    /**
+     * Uses the given string as the JSON body for the request with the {@code application/json} content type.
+     *
+     * @param json The string representation of the JSON to send in the request.
+     * @return This.
+     */
+    public RequestBuilder withJSON(String json) {
+        return withJSON("application/json", json);
+    }
+
+    /**
+     * Uses the given string as the JSON body for the request with the given content type.
+     *
+     * @param contentType The Content-Type header value
+     * @param json        The string representation of the JSON to send in the request.
+     * @return This.
+     */
+    public RequestBuilder withJSON(String contentType, String json) {
+        return withContentType(contentType).withBody(json);
+    }
+
+    /**
+     * Applies the given consumer to build a JSON body for the request with the {@code application/json} content type.
+     *
+     * @param consumer The {@link JSONBuilder} consumer to build request
+     * @return This.
+     * @throws Exception If the Jackson marshalling failed or consumer threw an exception.
+     */
+    public RequestBuilder withJSONBuilder(ThrowingConsumer<JSONBuilder> consumer) throws Exception {
+        return withJSONBuilder("application/json", consumer);
+    }
+
+    /**
+     * Applies the given consumer to build a JSON body for the request with the given content type.
+     *
+     * @param contentType The Content-Type header value
+     * @param consumer    The {@link JSONBuilder} consumer to build request
+     * @return This.
+     * @throws Exception If the Jackson marshalling failed or consumer threw an exception.
+     */
+    public RequestBuilder withJSONBuilder(String contentType, ThrowingConsumer<JSONBuilder> consumer) throws Exception {
+        ObjectMapper objectMapper = injector.getInstance(ObjectMapper.class);
+        JSONBuilder builder = new JSONBuilder(objectMapper);
+        consumer.accept(builder);
+        withJSON(contentType, builder.build());
+        return this;
+    }
+
+    /**
+     * Uses the given {@link Path} object to a JSON file as the JSON body for the request with the {@code application/json} content type.
+     *
+     * @param jsonFile The string representation of the JSON to send in the request.
+     * @param values   key value pairs of replacement values for use in the JSON file.
+     * @return This.
+     * @throws IOException If the file could not be loaded.
+     */
+    public RequestBuilder withJSONFile(Path jsonFile, Object... values)
+            throws IOException {
+        return withJSONFile("application/json", jsonFile, values);
+    }
+
+    /**
+     * Uses the given {@link Path} object to a JSON file as the JSON body for the request with the given content type.
+     *
+     * @param contentType The Content-Type header value
+     * @param jsonFile    The string representation of the JSON to send in the request.
+     * @param values      key value pairs of replacement values for use in the JSON file.
+     * @return This.
+     * @throws IOException If the file could not be loaded.
+     */
+    public RequestBuilder withJSONFile(String contentType, Path jsonFile, Object... values)
+            throws IOException {
+        return withContentType(contentType).withBodyFile(jsonFile, values);
+    }
+
+    /**
+     * Sets the locale that will be used.
+     *
+     * @param locale The locale.
+     * @return This.
+     */
+    public RequestBuilder withLocale(Locale locale) {
+        request.addLocales(locale);
+        return this;
+    }
+
+    /**
+     * Sets an HTTP request body parameter. This can be called multiple times with the same name it will create a list of values for the HTTP
+     * parameter.
+     *
+     * @param name  The name of the parameter.
+     * @param value The parameter value. This is an object so toString is called on it to convert it to a String.
+     * @return This.
+     */
+    public RequestBuilder withParameter(String name, Object value) {
+        requestBodyParameters.computeIfAbsent(name, key -> new ArrayList<>()).add(value != null ? value.toString() : null);
+        return this;
+    }
+
+    /**
+     * Sets HTTP request body parameters. This takes the provided collection and adds a request parameter for each item in the collection.
+     *
+     * @param name   The name of the parameter.
+     * @param values The collection of parameter values.
+     * @return This.
+     */
+    public RequestBuilder withParameters(String name, Collection<?> values) {
+        requestBodyParameters.computeIfAbsent(name, key -> new ArrayList<>()).addAll(values.stream().map(Object::toString).toList());
+        return this;
+    }
+
+    /**
+     * Sets HTTP request parameters from a query String that is already encoded and might contain multiple parameters. This will split the parameters up
+     * and decode them.
+     *
+     * @param query The query string.
+     * @return This.
+     */
+    public RequestBuilder withQueryString(String query) {
+        QueryStringTools.parseQueryString(query).forEach(this::withURLParameters);
+        return this;
+    }
+
+    /**
+     * Sets an HTTP request body parameter as a Prime MVC radio button widget. This can be called multiple times with the same name it will create a
+     * list of values for the HTTP parameter.
+     *
+     * @param name           The name of the parameter.
+     * @param checkedValue   The checked value of the checkbox.
+     * @param uncheckedValue The checked value of the checkbox.
+     * @param checked        If the checkbox is checked.
+     * @return This.
+     */
+    public RequestBuilder withRadio(String name, String checkedValue, String uncheckedValue, boolean checked) {
+        if (checked) {
+            setRequestBodyParameter(name, checkedValue);
+        }
+
+        setRequestBodyParameter(DefaultParameterParser.RADIOBUTTON_PREFIX + name, uncheckedValue);
+        return this;
+    }
+
+    /**
+     * Add a single request header. Calling this sequentially will just overwrite the previous value. If you wish to add a header multiple times, use
+     * {@link #withHeader(String, Object)} instead.
+     *
+     * @param name  The name of the header.
+     * @param value The value of the header.
+     * @return This.
+     */
+    public RequestBuilder withSingleHeader(String name, String value) {
+        request.setHeader(name, value);
+        return this;
+    }
+
+    /**
+     * Adds a header to the request only if the value is non-null. If the value is null, this method is a no-op.
+     * Follows the same pattern as {@link #withSingleHeader(String, String)}, it will replace if called sequentially
+     *
+     * @param name  The name of the header.
+     * @param value The value of the header, or {@code null} to skip adding the header.
+     * @return This.
+     */
+    public RequestBuilder withHeaderIfPresent(String name, String value) {
+        if (value != null) {
+            request.setHeader(name, value);
+        }
+        return this;
+    }
+
+    /**
+     * Add a single URL query string parameter.
+     *
+     * @param name  the name of the parameter.
+     * @param value the value of the parameter.
+     * @return This.
+     */
+    public RequestBuilder withURLParameter(String name, Object value) {
+        request.addURLParameter(name, value.toString());
+        return this;
+    }
+
+    /**
+     * Add all URL query string parameters.
+     *
+     * @param name   the name of the parameter.
+     * @param values The collection of parameter values.
+     * @return This.
+     */
+    public RequestBuilder withURLParameters(String name, Collection<?> values) {
+        request.addURLParameters(name, values.stream().map(Object::toString).collect(Collectors.toList()));
+        return this;
+    }
+
+    /**
+     * Append a url path segment to the current request URI.
+     * <p>
+     * For Example:
+     * <pre>
+     *   .simulator.test("/user/delete")
+     *             .withUrlSegment("bar")
+     *   </pre>
+     * This will result in a url of <code>/user/delete/bar</code>, this is equivalent to the following code:
+     * <pre>
+     *   .simulator.test("/user/delete/" + "bar")
+     *   </pre>
+     *
+     * @param value The url path segment. A null value will be ignored.
+     * @return This.
+     */
+    public RequestBuilder withURLSegment(Object value) {
+        if (value != null) {
+            String uri = request.getPath();
+            if (uri.charAt(uri.length() - 1) != '/') {
+                uri += '/';
+            }
+
+            request.setPath(uri + URITools.encodeURIPathSegment(value));
+        }
+
+        return this;
+    }
+
+    /**
+     * Bad name, use the correct URL method.
+     *
+     * @deprecated
+     */
+    @Deprecated
+    public RequestBuilder withUrlSegment(Object value) {
+        return withURLSegment(value);
+    }
+
+    HTTPResponseWrapper run() {
+        // Set the new request & response so that we can inject things below
+        HTTPObjectsHolder.clearRequest();
+        HTTPObjectsHolder.setRequest(request);
+        HTTPObjectsHolder.clearResponse();
+        HTTPObjectsHolder.setResponse(new HTTPResponse());
+
+        // Add a unique Id so that we can identify messages for this request in the observer.
+        String messageStoreId = UUID.randomUUID().toString();
+        messageObserver.setMessageStoreId(messageStoreId);
+        request.addHeader(TestMessageObserver.ObserverMessageStoreId, messageStoreId);
+
+        // New cookies were added to the request and not the user-agent, so we need to sync them to the user-agent here.
+        // Then we can add all cookies form the user-agent to the request.
+        userAgent.addCookies(request.getCookies());
+        request.getCookies().clear();
+        request.addCookies(userAgent.getCookies(request));
+
+        String scheme = useTLS ? "https://" : "http://";
+        URI requestURI = URI.create(scheme + "localhost:" + port + request.getPath());
+
+        // Referer for CSRF checks must be provided
+        if (request.getHeader("Referer") == null) {
+            request.setHeader("Referer", requestURI.toString());
+        }
+
+        request.setPort(port);
+        request.setHost(requestURI.getHost());
+        request.setScheme(requestURI.getScheme());
+
+        if (dPoPProofProvider != null) {
+            request.addHeader("DPoP", dPoPProofProvider.generateDPoPProof(request.getMethod(), requestURI.toString(), this.dPoPToken));
+        }
+
+        // Now that the cookies are ready, if the CSRF token is enabled and the parameter isn't set, we set it to be consistent
+        // since the [@control.form] would normally set that into the form and into the request.
+        if (request.getMethod() == HTTPMethod.POST) {
+            MVCConfiguration configuration = injector.getInstance(MVCConfiguration.class);
+            if (configuration.csrfEnabled()) {
+                CSRFProvider csrfProvider = injector.getInstance(CSRFProvider.class);
+                if (csrfProvider.getTokenFromRequest(request) == null) {
+                    String token = csrfProvider.getToken(request);
+                    if (token != null) {
+                        String parameterName = csrfProvider.getParameterName();
+                        requestBodyParameters.put(parameterName, List.of(token));
+                    }
+                }
+            }
+        }
+
+        // Allow the caller to consume the HTTP request in order to mutate it and what not.
+        if (httpRequestConsumer != null) {
+            httpRequestConsumer.accept(request);
+        }
+
+        List<Locale> locales = request.getLocales();
+        String contentType = request.getContentType();
+        Charset characterEncoding = request.getCharacterEncoding();
+        HTTPMethod method = request.getMethod();
+
+        Map<String, List<String>> urlParameters = request.getParameters();
+        List<FileInfo> files = request.getFiles();
+        BodyPublisher bodyPublisher = BodyPublishers.noBody();
+        // We'll use this to keep the java-http HTTP Request in sync
+        InputStream inputStream = null;
+
+        if (files != null && !files.isEmpty()) {
+            List<MultipartFileUpload> fileUploads = files.stream()
+                    .map(fi -> new MultipartFileUpload(fi.contentType, fi.file, fi.fileName, fi.name))
+                    .collect(Collectors.toList());
+            MultipartBodyHandler multipartBodyHandler = new MultipartBodyHandler(new Multiparts(fileUploads, requestBodyParameters));
+            bodyPublisher = BodyPublishers.ofByteArray(multipartBodyHandler.getBody());
+            if (contentType == null) {
+                contentType = "multipart/form-data; boundary=" + multipartBodyHandler.boundary;
+            }
+            inputStream = new ByteArrayInputStream(multipartBodyHandler.getBody());
+        } else if (body != null) {
+            bodyPublisher = BodyPublishers.ofByteArray(body);
+            inputStream = new ByteArrayInputStream(body);
+        } else if (!requestBodyParameters.isEmpty()) {
+            byte[] formBody = new FormBodyPublisher(requestBodyParameters).getBody();
+            bodyPublisher = BodyPublishers.ofByteArray(formBody);
+            if (contentType == null) {
+                contentType = "application/x-www-form-urlencoded";
+            }
+            inputStream = (new ByteArrayInputStream(formBody));
+        }
+
+        // Keep this HTTP request in sync so that we can optionally use it in various test use cases.
+        if (inputStream != null) {
+            request.setInputStream(inputStream);
+        }
+
+        var requestBuilder = HttpRequest.newBuilder()
+                .method(request.getMethod().name(), bodyPublisher);
+
+        if (locales.isEmpty()) {
+            // request.getLocale() returns a default locale if none are set by httpRequestConsumer but
+            // we still want to set to the system's default, if none were explicitly set.
+            locales = List.of(Locale.getDefault());
+        }
+        requestBuilder.setHeader("Accept-Language", locales.stream().map(Locale::toLanguageTag).collect(Collectors.joining(", ")));
+
+        if (contentType != null) {
+            requestBuilder.setHeader(Headers.ContentType, contentType + (characterEncoding != null ? "; charset=" + characterEncoding : ""));
+
+            // Keep this HTTP request in sync so that we can optionally use it in various test use cases.
+            request.setContentType(contentType);
+        }
+
+        // Copy over headers
+        request.getHeaders().forEach((name, values) ->
+                values.forEach(value -> requestBuilder.header(name, value)));
+
+        // Set cookies
+        if (request.getHeaders().keySet().stream().noneMatch(name -> name.equalsIgnoreCase(Headers.Cookie)) && !request.getCookies().isEmpty()) {
+            String header = request.getCookies()
+                    .stream()
+                    .map(io.fusionauth.http.Cookie::toRequestHeader)
+                    .collect(Collectors.joining("; "));
+            requestBuilder.setHeader(Headers.Cookie, header);
+        }
+
+        // Set the UserAgent header if not already set
+        // - Do this because the default UserAgent string will include the Java version string which is annoying to update in tests.
+        if (request.getHeaders().keySet().stream().noneMatch(name -> name.equalsIgnoreCase(Headers.UserAgent))) {
+            requestBuilder.setHeader(Headers.UserAgent, "Java HttpClient");
+        }
+
+        QueryStringBuilder queryStringBuilder = QueryStringBuilder.builder();
+        urlParameters.forEach((name, values) -> values.forEach(value -> queryStringBuilder.with(name, value)));
+
+        URI fullURI = urlParameters.isEmpty()
+                ? requestURI
+                : URI.create(requestURI + "?" + queryStringBuilder.build());
+
+        requestBuilder.uri(fullURI);
+
+        HTTPResponseWrapper result = new HTTPResponseWrapper();
+        try {
+            result.response = HttpClientInstance.send(requestBuilder.build(),
+                    BodyHandlers.ofByteArray());
+        } catch (Exception e) {
+            result.exception = e;
+            result.init();
+            return result;
+        }
+
+        // Extract the cookies and put them in the UserAgent
+        userAgent.addCookies(getCookies(result.response)
+                .stream()
+                .map(c -> new Cookie().with(c1 -> c1.domain = c.domain)
+                        .with(c1 -> c1.expires = c.expires)
+                        .with(c1 -> c1.httpOnly = c.httpOnly)
+                        .with(c1 -> c1.maxAge = c.maxAge)
+                        .with(c1 -> c1.name = c.name)
+                        .with(c1 -> c1.path = c.path)
+                        .with(c1 -> c1.sameSite = c.sameSite != null ? Cookie.SameSite.valueOf(c.sameSite.name()) : null)
+                        .with(c1 -> c1.secure = c.secure).with(c1 -> c1.value = c.value))
+                .collect(Collectors.toList()));
+
+        result.init();
+        return result;
+    }
+
+    private List<io.fusionauth.http.Cookie> getCookies(HttpResponse<byte[]> response) {
+        List<String> cookies = response.headers().allValues(Headers.SetCookie.toLowerCase());
+        if (cookies != null && !cookies.isEmpty()) {
+            return cookies.stream().map(io.fusionauth.http.Cookie::fromResponseHeader).filter(Objects::nonNull).collect(Collectors.toList());
+        }
+
+        return List.of();
+    }
+
+    private void setRequestBodyParameter(String name, Object value) {
+        List<String> values = new ArrayList<>();
+        values.add(value.toString());
+        requestBodyParameters.put(name, values);
+    }
+
+    public interface HTTPRequestConsumer {
+        /**
+         * @param httpRequest the http request
+         */
+        void accept(HTTPRequest httpRequest);
+    }
 }


### PR DESCRIPTION
# Problem

As of https://github.com/prime-framework/prime-mvc/pull/74, we always put headers on cookie values when set managed cookies, even when the cookies are neither compressed nor encrypted.

The current code makes it easy though, when setting cookies for tests with `withCookie` and the simulator, to not include that header on cookie values, and then behave different than managed cookies would if they were set from action classes.

# Solution

1. Change `withCookie` to always use `CookieTools.toCookie`, even when not encrypting or compressing.
2. Preserve the "raw" approach by not doing this if a `Cookie` object is passed in.