### PR TITLE
fix: exception handling for JsonParseException in content handler

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.10.1", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.10.2", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,11 @@
 <!--
-  ~ Copyright (c) 2023-2025, FusionAuth, All Rights Reserved
+  ~ Copyright (c) 2023-2026, FusionAuth, All Rights Reserved
   --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.10.0</version>
+  <version>5.10.2</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
@@ -141,6 +141,10 @@ public abstract class BaseJacksonContentHandler implements ContentHandler {
         String field = buildField(e);
         messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidJSON]", messageProvider.getMessage("[invalidJSON]", field, "Unrecognized property", e.getMessage())));
         throw new ValidationException(e);
+      } catch (JsonParseException e) {
+        logger.debug("Error parsing JSON request body - body is not valid JSON", e);
+        messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidRequestBody]", messageProvider.getMessage("[invalidRequestBody]")));
+        throw new ValidationException(e);
       } catch (JsonMappingException e) {
         logger.debug("Error parsing JSON request", e);
 

--- a/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
@@ -1,17 +1,5 @@
 /*
- * Copyright (c) 2013-2025, Inversoft Inc., All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
+ * Copyright (c) 2013-2026, FusionAuth, All Rights Reserved
  */
 package org.primeframework.mvc.content.json;
 
@@ -143,7 +131,7 @@ public abstract class BaseJacksonContentHandler implements ContentHandler {
         throw new ValidationException(e);
       } catch (JsonParseException e) {
         logger.debug("Error parsing JSON request body - body is not valid JSON", e);
-        messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidRequestBody]", messageProvider.getMessage("[invalidRequestBody]")));
+        messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidJSON]", messageProvider.getMessage("[invalidJSON]", "request body", "Request body is not valid JSON", e.getMessage())));
         throw new ValidationException(e);
       } catch (JsonMappingException e) {
         logger.debug("Error parsing JSON request", e);

--- a/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
+++ b/src/main/java/org/primeframework/mvc/content/json/BaseJacksonContentHandler.java
@@ -1,15 +1,19 @@
 /*
- * Copyright (c) 2013-2026, FusionAuth, All Rights Reserved
+ * Copyright (c) 2013-2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
  */
 package org.primeframework.mvc.content.json;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -36,6 +40,15 @@ import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 import org.primeframework.mvc.validation.ValidationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static org.primeframework.mvc.util.ObjectTools.defaultIfNull;
 
 /**

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
@@ -1,14 +1,19 @@
 /*
- * Copyright (c) 2001-2026, FusionAuth, All Rights Reserved
+ * Copyright (c) 2001-2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
  */
 package org.primeframework.mvc.content.json;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
@@ -23,28 +28,22 @@ import org.primeframework.mvc.action.ActionInvocationStore;
 import org.primeframework.mvc.action.ExecuteMethodConfiguration;
 import org.primeframework.mvc.action.config.ActionConfiguration;
 import org.primeframework.mvc.content.json.JacksonActionConfiguration.RequestMember;
-import org.primeframework.mvc.message.FieldMessage;
-import org.primeframework.mvc.message.MessageStore;
-import org.primeframework.mvc.message.MessageType;
-import org.primeframework.mvc.message.SimpleFieldMessage;
-import org.primeframework.mvc.message.SimpleMessage;
+import org.primeframework.mvc.message.*;
 import org.primeframework.mvc.message.l10n.MessageProvider;
-import org.primeframework.mvc.message.l10n.MissingMessageException;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 import org.primeframework.mvc.validation.ValidationException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.createStrictMock;
-import static org.easymock.EasyMock.eq;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.easymock.EasyMock.*;
+import static org.testng.Assert.*;
 
 /**
  * Tests the jackson configurator test.
@@ -485,37 +484,6 @@ public class JacksonContentHandlerTest extends PrimeBaseTest {
 
     assertNull(action.jsonRequest);
     verify(store, messageProvider, messageStore);
-  }
-
-  @Test(expectedExceptions = MissingMessageException.class)
-  public void handleMalformedBody_missingMessage() throws IOException {
-    Map<Class<?>, Object> additionalConfig = new HashMap<>();
-    Map<HTTPMethod, RequestMember> requestMembers = new HashMap<>();
-    requestMembers.put(HTTPMethod.POST, new RequestMember("jsonRequest", UserField.class));
-    additionalConfig.put(JacksonActionConfiguration.class, new JacksonActionConfiguration(requestMembers, null, null));
-
-    KitchenSinkAction action = new KitchenSinkAction(null);
-    ActionConfiguration config = new ActionConfiguration(KitchenSinkAction.class, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Collections.emptyList(), null, additionalConfig, null, null, null, null, null);
-
-    ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);
-    expect(store.getCurrent()).andReturn(
-        new ActionInvocation(action, new ExecuteMethodConfiguration(HTTPMethod.POST, null, null), "/action", null, config));
-    replay(store);
-
-    HTTPRequest request = new HTTPRequest();
-    request.setInputStream(new ByteArrayInputStream("undefined".getBytes()));
-    request.setContentLength((long) "undefined".getBytes().length);
-    request.setContentType("application/json");
-
-    MessageProvider messageProvider = createStrictMock(MessageProvider.class);
-    expect(messageProvider.getMessage(eq("[invalidJSON]"), eq("request body"), eq("Request body is not valid JSON"), isA(String.class)))
-        .andThrow(new MissingMessageException("Message not found for key [invalidJSON]"));
-    replay(messageProvider);
-
-    MessageStore messageStore = createNiceMock(MessageStore.class);
-    replay(messageStore);
-
-    new JacksonContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore).handle();
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
@@ -1,5 +1,17 @@
 /*
- * Copyright (c) 2001-2026, FusionAuth, All Rights Reserved
+ * Copyright (c) 2001-2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
  */
 package org.primeframework.mvc.content.json;
 

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright (c) 2001-2026, Inversoft Inc., All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
+ * Copyright (c) 2001-2026, FusionAuth, All Rights Reserved
  */
 package org.primeframework.mvc.content.json;
 
@@ -41,6 +29,7 @@ import org.primeframework.mvc.message.MessageType;
 import org.primeframework.mvc.message.SimpleFieldMessage;
 import org.primeframework.mvc.message.SimpleMessage;
 import org.primeframework.mvc.message.l10n.MessageProvider;
+import org.primeframework.mvc.message.l10n.MissingMessageException;
 import org.primeframework.mvc.parameter.el.ExpressionEvaluator;
 import org.primeframework.mvc.validation.ValidationException;
 import org.testng.annotations.DataProvider;
@@ -496,6 +485,37 @@ public class JacksonContentHandlerTest extends PrimeBaseTest {
 
     assertNull(action.jsonRequest);
     verify(store, messageProvider, messageStore);
+  }
+
+  @Test(expectedExceptions = MissingMessageException.class)
+  public void handleMalformedBody_missingMessage() throws IOException {
+    Map<Class<?>, Object> additionalConfig = new HashMap<>();
+    Map<HTTPMethod, RequestMember> requestMembers = new HashMap<>();
+    requestMembers.put(HTTPMethod.POST, new RequestMember("jsonRequest", UserField.class));
+    additionalConfig.put(JacksonActionConfiguration.class, new JacksonActionConfiguration(requestMembers, null, null));
+
+    KitchenSinkAction action = new KitchenSinkAction(null);
+    ActionConfiguration config = new ActionConfiguration(KitchenSinkAction.class, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Collections.emptyList(), null, additionalConfig, null, null, null, null, null);
+
+    ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);
+    expect(store.getCurrent()).andReturn(
+        new ActionInvocation(action, new ExecuteMethodConfiguration(HTTPMethod.POST, null, null), "/action", null, config));
+    replay(store);
+
+    HTTPRequest request = new HTTPRequest();
+    request.setInputStream(new ByteArrayInputStream("undefined".getBytes()));
+    request.setContentLength((long) "undefined".getBytes().length);
+    request.setContentType("application/json");
+
+    MessageProvider messageProvider = createStrictMock(MessageProvider.class);
+    expect(messageProvider.getMessage(eq("[invalidJSON]"), eq("request body"), eq("Request body is not valid JSON"), isA(String.class)))
+        .andThrow(new MissingMessageException("Message not found for key [invalidJSON]"));
+    replay(messageProvider);
+
+    MessageStore messageStore = createNiceMock(MessageStore.class);
+    replay(messageStore);
+
+    new JacksonContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore).handle();
   }
 
   @Test

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
@@ -479,11 +479,11 @@ public class JacksonContentHandlerTest extends PrimeBaseTest {
     request.setContentType("application/json");
 
     MessageProvider messageProvider = createStrictMock(MessageProvider.class);
-    expect(messageProvider.getMessage(eq("[invalidRequestBody]"))).andReturn("The request body is not valid JSON.");
+    expect(messageProvider.getMessage(eq("[invalidJSON]"), eq("request body"), eq("Request body is not valid JSON"), isA(String.class))).andReturn("The request body is not valid JSON.");
     replay(messageProvider);
 
     MessageStore messageStore = createStrictMock(MessageStore.class);
-    messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidRequestBody]", "The request body is not valid JSON."));
+    messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidJSON]", "The request body is not valid JSON."));
     replay(messageStore);
 
     JacksonContentHandler handler = new JacksonContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore);

--- a/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
+++ b/src/test/java/org/primeframework/mvc/content/json/JacksonContentHandlerTest.java
@@ -1,17 +1,5 @@
 /*
- * Copyright (c) 2001-2025, Inversoft Inc., All Rights Reserved
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific
- * language governing permissions and limitations under the License.
+ * Copyright (c) 2001-2026, FusionAuth, All Rights Reserved
  */
 package org.primeframework.mvc.content.json;
 
@@ -455,6 +443,46 @@ public class JacksonContentHandlerTest extends PrimeBaseTest {
 
     assertNull(action.jsonRequest);
 
+    verify(store, messageProvider, messageStore);
+  }
+
+  @Test
+  public void handleMalformedBody() throws IOException {
+    Map<Class<?>, Object> additionalConfig = new HashMap<>();
+    Map<HTTPMethod, RequestMember> requestMembers = new HashMap<>();
+    requestMembers.put(HTTPMethod.POST, new RequestMember("jsonRequest", UserField.class));
+    additionalConfig.put(JacksonActionConfiguration.class, new JacksonActionConfiguration(requestMembers, null, null));
+
+    KitchenSinkAction action = new KitchenSinkAction(null);
+    ActionConfiguration config = new ActionConfiguration(KitchenSinkAction.class, false, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Collections.emptyList(), null, additionalConfig, null, null, null, null, null);
+
+    ActionInvocationStore store = createStrictMock(ActionInvocationStore.class);
+    expect(store.getCurrent()).andReturn(
+        new ActionInvocation(action, new ExecuteMethodConfiguration(HTTPMethod.POST, null, null), "/action", null, config));
+    replay(store);
+
+    HTTPRequest request = new HTTPRequest();
+    request.setInputStream(new ByteArrayInputStream("undefined".getBytes()));
+    request.setContentLength((long) "undefined".getBytes().length);
+    request.setContentType("application/json");
+
+    MessageProvider messageProvider = createStrictMock(MessageProvider.class);
+    expect(messageProvider.getMessage(eq("[invalidRequestBody]"))).andReturn("The request body is not valid JSON.");
+    replay(messageProvider);
+
+    MessageStore messageStore = createStrictMock(MessageStore.class);
+    messageStore.add(new SimpleMessage(MessageType.ERROR, "[invalidRequestBody]", "The request body is not valid JSON."));
+    replay(messageStore);
+
+    JacksonContentHandler handler = new JacksonContentHandler(request, store, new ObjectMapper(), expressionEvaluator, messageProvider, messageStore);
+    try {
+      handler.handle();
+      fail("Should have thrown");
+    } catch (ValidationException e) {
+      // Expected
+    }
+
+    assertNull(action.jsonRequest);
     verify(store, messageProvider, messageStore);
   }
 

--- a/src/test/web/messages/package.properties
+++ b/src/test/web/messages/package.properties
@@ -23,7 +23,6 @@ format_key=Super Package Message %s %s %s
 [UnsupportedContentType]=Unsupported [Content-Type] HTTP request header value of [%s].
 
 [invalidJSON]=Unable to parse JSON. The property [%s] was invalid. The error was [%s]. The detailed exception was [%s].
-[invalidRequestBody]=The request body is not valid JSON.
 
 # Default messages
 [blank]=Required

--- a/src/test/web/messages/package.properties
+++ b/src/test/web/messages/package.properties
@@ -23,6 +23,7 @@ format_key=Super Package Message %s %s %s
 [UnsupportedContentType]=Unsupported [Content-Type] HTTP request header value of [%s].
 
 [invalidJSON]=Unable to parse JSON. The property [%s] was invalid. The error was [%s]. The detailed exception was [%s].
+[invalidRequestBody]=The request body is not valid JSON.
 
 # Default messages
 [blank]=Required


### PR DESCRIPTION
## Problem 
- JsonParseException (completely malformed JSON, e.g. undefined, broken syntax) was not caught in BaseJacksonContentHandler; only JsonMappingException and UnrecognizedPropertyException were handled, causing the exception to propagate unexpectedly.

## Solution
- added a dedicated catch block for JsonParseException that adds a [invalidRequestBody] general error message and throws ValidationException. Added the message key to package.properties and covered it with a unit test.