### PR TITLE
Use ASM9 API (now that using ASM9 dependency)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
       - name: setup java
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
         shell: /usr/bin/bash -l -e -o pipefail {0}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: setup java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: |
@@ -49,7 +49,7 @@ jobs:
         run: |
           sb clean int
       - name: capture reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: success() || failure() # always run even if the previous step fails
         with:
           name: testng_reports

--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2025, Inversoft Inc., All Rights Reserved
+ * Copyright (c) 2014-2026, Inversoft Inc., All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,73 +29,73 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.10.3", licenses: ["ApacheV2_0"]) {
-  workflow {
-    fetch {
-      // Dependency resolution order:
-      //
-      // 1. Hit the savant cache
-      cache()
-      //
-      // 2. Look in public savant repo
-      url(url: "https://repository.savantbuild.org")
-      //
-      // 3. No dice, see if we can find it in Maven central
-      maven()
+project(group: "org.primeframework", name: "prime-mvc", version: "5.11.0", licenses: ["ApacheV2_0"]) {
+    workflow {
+        fetch {
+            // Dependency resolution order:
+            //
+            // 1. Hit the savant cache
+            cache()
+            //
+            // 2. Look in public savant repo
+            url(url: "https://repository.savantbuild.org")
+            //
+            // 3. No dice, see if we can find it in Maven central
+            maven()
+        }
+        publish {
+            cache()
+        }
+        semanticVersions {
+            mapping(id: "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava", version: "9999.0.0")
+            mapping(id: "com.google.guava:guava-parent:26.0-android", version: "26.0.0")
+        }
     }
-    publish {
-      cache()
-    }
-    semanticVersions {
-      mapping(id: "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava", version: "9999.0.0")
-      mapping(id: "com.google.guava:guava-parent:26.0-android", version: "26.0.0")
-    }
-  }
 
-  publishWorkflow {
-    subversion(repository: "https://svn.savantbuild.org")
-  }
+    publishWorkflow {
+        subversion(repository: "https://svn.savantbuild.org")
+    }
 
-  dependencies {
-    group(name: "compile") {
-      dependency(id: "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
-      dependency(id: "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
-      dependency(id: "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
-      dependency(id: "com.github.java-json-tools:json-patch:${jsonPatchVersion}")
-      dependency(id: "com.google.code.findbugs:jsr305:3.0.2", skipCompatibilityCheck: true)
-      dependency(id: "com.google.inject:guice:${guiceVersion}")
-      dependency(id: "io.dropwizard.metrics:metrics-core:${dropWizardVersion}")
-      dependency(id: "io.fusionauth:fusionauth-jwt:${fusionAuthJWTVersion}")
-      dependency(id: "io.fusionauth:java-http:${javaHTTPVersion}")
-      dependency(id: "jakarta.inject:jakarta.inject-api:2.0.1")
-      dependency(id: "javax.inject:javax.inject:1.0.0")
-      dependency(id: "org.freemarker:freemarker:${freemarkerVersion}")
-      dependency(id: "org.ow2.asm:asm:${asmVersion}")
-      dependency(id: "org.slf4j:slf4j-api:${slf4jVersion}", skipCompatibilityCheck: true)
+    dependencies {
+        group(name: "compile") {
+            dependency(id: "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+            dependency(id: "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}")
+            dependency(id: "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
+            dependency(id: "com.github.java-json-tools:json-patch:${jsonPatchVersion}")
+            dependency(id: "com.google.code.findbugs:jsr305:3.0.2", skipCompatibilityCheck: true)
+            dependency(id: "com.google.inject:guice:${guiceVersion}")
+            dependency(id: "io.dropwizard.metrics:metrics-core:${dropWizardVersion}")
+            dependency(id: "io.fusionauth:fusionauth-jwt:${fusionAuthJWTVersion}")
+            dependency(id: "io.fusionauth:java-http:${javaHTTPVersion}")
+            dependency(id: "jakarta.inject:jakarta.inject-api:2.0.1")
+            dependency(id: "javax.inject:javax.inject:1.0.0")
+            dependency(id: "org.freemarker:freemarker:${freemarkerVersion}")
+            dependency(id: "org.ow2.asm:asm:${asmVersion}")
+            dependency(id: "org.slf4j:slf4j-api:${slf4jVersion}", skipCompatibilityCheck: true)
+        }
+        group(name: "runtime") {
+            dependency(id: "com.google.guava:guava:${guavaVersion}", skipCompatibilityCheck: true)
+        }
+        group(name: "test-compile", export: false) {
+            dependency(id: "org.easymock:easymock:${easyMockVersion}")
+            dependency(id: "org.testng:testng:${testngVersion}")
+            dependency(id: "org.jsoup:jsoup:${jsoupVersion}")
+        }
+        group(name: "test-runtime", export: false) {
+            dependency(id: "ch.qos.logback:logback-classic:${logbackVersion}")
+            dependency(id: "ch.qos.logback:logback-core:${logbackVersion}")
+        }
     }
-    group(name: "runtime") {
-      dependency(id: "com.google.guava:guava:${guavaVersion}", skipCompatibilityCheck: true)
-    }
-    group(name: "test-compile", export: false) {
-      dependency(id: "org.easymock:easymock:${easyMockVersion}")
-      dependency(id: "org.testng:testng:${testngVersion}")
-      dependency(id: "org.jsoup:jsoup:${jsoupVersion}")
-    }
-    group(name: "test-runtime", export: false) {
-      dependency(id: "ch.qos.logback:logback-classic:${logbackVersion}")
-      dependency(id: "ch.qos.logback:logback-core:${logbackVersion}")
-    }
-  }
 
-  publications {
-    standard()
-    main {
-      publication(name: "${project.name}-simulator", type: "jar",
-                  file: "build/jars/${project.name}-simulator-${project.version}.jar",
-                  source: "build/jars/${project.name}-simulator-${project.version}-src.jar"
-      )
+    publications {
+        standard()
+        main {
+            publication(name: "${project.name}-simulator", type: "jar",
+                    file: "build/jars/${project.name}-simulator-${project.version}.jar",
+                    source: "build/jars/${project.name}-simulator-${project.version}-src.jar"
+            )
+        }
     }
-  }
 }
 
 // Plugins
@@ -113,89 +113,89 @@ javaTestNG.settings.javaVersion = "21"
 javaTestNG.settings.jvmArguments = "--add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED"
 
 target(name: "clean", description: "Cleans the project") {
-  java.clean()
+    java.clean()
 }
 
 target(name: "compile", description: "Compiles the project") {
-  java.compileMain()
+    java.compileMain()
 
-  // Allow the user of sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl in tests (but not in production code)
-  java.settings.compilerArguments = "-XDignore.symbol.file --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.util=ALL-UNNAMED"
-  java.compileTest()
+    // Allow the user of sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl in tests (but not in production code)
+    java.settings.compilerArguments = "-XDignore.symbol.file --add-exports java.base/sun.security.x509=ALL-UNNAMED --add-exports java.base/sun.security.util=ALL-UNNAMED"
+    java.compileTest()
 
-  file.copy(to: "build/classes/main") {
-    fileSet(dir: "src/main/ftl")
-  }
+    file.copy(to: "build/classes/main") {
+        fileSet(dir: "src/main/ftl")
+    }
 }
 
 target(name: "jar", description: "JARs the project", dependsOn: ["compile"]) {
-  java.jar()
+    java.jar()
 
-  // Create a separate test jar that only includes org/primeframework
-  file.copy(to: "build/classes/simulator") {
-    fileSet(dir: "build/classes/test", includePatterns: [~/org\/primeframework.+/])
-  }
+    // Create a separate test jar that only includes org/primeframework
+    file.copy(to: "build/classes/simulator") {
+        fileSet(dir: "build/classes/test", includePatterns: [~/org\/primeframework.+/])
+    }
 
-  // Create a separate test jar that only includes org/primeframework
-  file.copy(to: "build/src/simulator") {
-    fileSet(dir: "src/test/java", includePatterns: [~/org\/primeframework.+/])
-  }
+    // Create a separate test jar that only includes org/primeframework
+    file.copy(to: "build/src/simulator") {
+        fileSet(dir: "src/test/java", includePatterns: [~/org\/primeframework.+/])
+    }
 
-  file.jar(file: "build/jars/${project.name}-simulator-${project.version}.jar") {
-    fileSet(dir: "build/classes/simulator")
-  }
+    file.jar(file: "build/jars/${project.name}-simulator-${project.version}.jar") {
+        fileSet(dir: "build/classes/simulator")
+    }
 
-  file.jar(file: "build/jars/${project.name}-simulator-${project.version}-src.jar") {
-    fileSet(dir: "build/src/simulator")
-  }
+    file.jar(file: "build/jars/${project.name}-simulator-${project.version}-src.jar") {
+        fileSet(dir: "build/src/simulator")
+    }
 }
 
 target(name: "pom", description: "Updates the pom.xml file") {
-  updatePOM()
+    updatePOM()
 }
 
 target(name: "test", description: "Runs the project's tests", dependsOn: ["jar"]) {
-  javaTestNG.test()
+    javaTestNG.test()
 }
 
 target(name: "doc", description: "Generate the project's JavaDoc", dependsOn: ["jar"]) {
-  java.document()
+    java.document()
 }
 
 target(name: "int", description: "Releases a local integration build of the project", dependsOn: ["test"]) {
-  dependency.integrate()
+    dependency.integrate()
 }
 
 target(name: "list-unused-dependencies", description: "Lists the unused dependencies of the project", dependsOn: ["compile"]) {
-  dependency.listUnusedDependencies()
+    dependency.listUnusedDependencies()
 }
 
 target(name: "release", description: "Releases a full version of the project", dependsOn: ["test"]) {
-  release.release()
+    release.release()
 }
 
 target(name: "idea", description: "Updates the IntelliJ IDEA module file") {
-  idea.iml()
-  updatePOM()
+    idea.iml()
+    updatePOM()
 }
 
 void updatePOM() {
-  pom.update()
+    pom.update()
 
-  // Note that the POM plugin does not handle non semantic versions correctly.
-  // - However, these dependencies are coming from savant, so we do not know the version they were in Maven.
-  //   The longer term fix I think it is to delete these from savant and just pull them from Maven, but there are
-  //   complications in doing that unless we wholesale delete all artifacts from Savant that can be found in Maven
-  //   all at once.
-  // - We can live with this for a while longer. Or if we can upgrade these deps then we don't need these mappings
-  //   assuming we can pull them from maven.
-  //   But I don't know that we will ever update inject:1.0.0.
-  file.copy(to: ".") {
-    fileSet(dir: ".", includePatterns: [~/pom.xml/])
-    // com.github.java-json-tools:json-patch:1.13.0 -> 1.13
-    filter(token: "<version>1.13.0</version>", value: "<version>1.13</version>")
-    // javax.inject:javax.inject:1.0.0 -> 1
-    filter(token: "<artifactId>javax.inject</artifactId>\n      <version>1.0.0</version>",
-           value: "<artifactId>javax.inject</artifactId>\n      <version>1</version>")
-  }
+    // Note that the POM plugin does not handle non semantic versions correctly.
+    // - However, these dependencies are coming from savant, so we do not know the version they were in Maven.
+    //   The longer term fix I think it is to delete these from savant and just pull them from Maven, but there are
+    //   complications in doing that unless we wholesale delete all artifacts from Savant that can be found in Maven
+    //   all at once.
+    // - We can live with this for a while longer. Or if we can upgrade these deps then we don't need these mappings
+    //   assuming we can pull them from maven.
+    //   But I don't know that we will ever update inject:1.0.0.
+    file.copy(to: ".") {
+        fileSet(dir: ".", includePatterns: [~/pom.xml/])
+        // com.github.java-json-tools:json-patch:1.13.0 -> 1.13
+        filter(token: "<version>1.13.0</version>", value: "<version>1.13</version>")
+        // javax.inject:javax.inject:1.0.0 -> 1
+        filter(token: "<artifactId>javax.inject</artifactId>\n      <version>1.0.0</version>",
+                value: "<artifactId>javax.inject</artifactId>\n      <version>1</version>")
+    }
 }

--- a/build.savant
+++ b/build.savant
@@ -29,7 +29,7 @@ logbackVersion = "1.5.13"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 
-project(group: "org.primeframework", name: "prime-mvc", version: "5.11.0", licenses: ["ApacheV2_0"]) {
+project(group: "org.primeframework", name: "prime-mvc", version: "5.10.4", licenses: ["ApacheV2_0"]) {
     workflow {
         fetch {
             // Dependency resolution order:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.primeframework</groupId>
   <artifactId>prime-mvc</artifactId>
-  <version>5.10.3</version>
+  <version>5.10.4</version>
   <packaging>jar</packaging>
 
   <name>FusionAuth App</name>

--- a/src/main/java/org/primeframework/mvc/util/ClassClasspathResolver.java
+++ b/src/main/java/org/primeframework/mvc/util/ClassClasspathResolver.java
@@ -15,23 +15,6 @@
  */
 package org.primeframework.mvc.util;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
-import java.util.jar.JarEntry;
-import java.util.jar.JarFile;
-
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -39,6 +22,13 @@ import org.objectweb.asm.Opcodes;
 import org.primeframework.mvc.PrimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.lang.annotation.Annotation;
+import java.util.*;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
 import static java.util.Arrays.asList;
 
 /**
@@ -53,406 +43,406 @@ import static java.util.Arrays.asList;
  * @author Brian Pontarelli
  */
 public class ClassClasspathResolver<U> {
-  private final Logger logger = LoggerFactory.getLogger(ClassClasspathResolver.class);
-
-  /**
-   * Attempts to load the given file into a ClassReader.
-   *
-   * @param file The file to load.
-   * @return The ClassReader and never null.
-   * @throws IOException If the file doesn't point to a valid class.
-   */
-  public static ClassReader load(File file) throws IOException {
-    try {
-      return new ClassReader(new FileInputStream(file));
-    } catch (IOException e) {
-      throw new IOException("Error parsing class file at [" + file.getAbsolutePath() + "]", e);
-    }
-  }
-
-  /**
-   * Attempts to load the JarEntry into a ClassReader.
-   *
-   * @param jar      The JAR file that the entry is in.
-   * @param jarFile  The JAR file used to get the InputStream to the entry.
-   * @param jarEntry The JAR entry to load.
-   * @return The ClassReader and never null.
-   * @throws IOException If the JarEntry doesn't point to a valid class.
-   */
-  public static ClassReader load(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
-    try {
-      return new ClassReader(jarFile.getInputStream(jarEntry));
-    } catch (IOException e) {
-      throw new IOException("Error parsing class file at [" + jar.getAbsolutePath() + "!/" + jarEntry.getName() + "]", e);
-    }
-  }
-
-  /**
-   * Attempts to discover resources that pass the test.
-   * <p/>
-   * Examples:
-   * <p/>
-   * <pre>
-   * locators: foo bar
-   *
-   * JAR file in classpath
-   * ----------------------
-   * com/example/foo/sub/File.class
-   *
-   * Directory in classpath (/opt/classpath)
-   * ----------------------
-   * /opt/classpath/com/example/bar/sub/File2.class
-   *
-   * This will find directories com/example/foo and com/example/bar
-   * </pre>
-   *
-   * @param test      The test implementation to determine matching resources.
-   * @param recursive If true, this will recurse into sub-directories. If false, this will only look in the directories
-   *                  given.
-   * @param locators  A list of directory locators that are used to locate directories to find resources in.
-   * @return The matching set.
-   * @throws IOException If there was any errors while inspecting the classpath.
-   */
-  public Set<Class<U>> findByLocators(Test<Class<U>> test, boolean recursive, String... locators)
-      throws IOException {
-    if (locators == null) {
-      return null;
-    }
-
-    Classpath classpath = Classpath.getCurrentClassPath();
-    List<String> names = classpath.getNames();
-    Set<Class<U>> matches = new HashSet<>();
-    for (String name : names) {
-      File f = new File(name);
-      if (f.isDirectory()) {
-        for (String locator : locators) {
-          Set<File> directories = findDirectories(f, locator);
-          for (File dir : directories) {
-            matches.addAll(loadFromDirectory(dir, test, recursive));
-          }
-        }
-      } else if (f.isFile()) {
-        matches.addAll(loadFromJar(f, test, recursive, asList(locators), true));
-      }
-    }
-
-    return matches;
-  }
-
-  private Set<File> findDirectories(File dir, String locator) {
-    // Loop over the files using tail-recursion
-    Set<File> directories = new HashSet<>();
-    Queue<File> files = new LinkedList<>(safeListFiles(dir, File::isDirectory));
-    while (!files.isEmpty()) {
-      File file = files.poll();
-      if (file.isDirectory() && file.getName().equals(locator)) {
-        directories.add(file);
-      } else if (file.isDirectory()) {
-        files.addAll(safeListFiles(file, null));
-      }
-    }
-
-    return directories;
-  }
-
-  private Collection<Class<U>> loadFromDirectory(File dir, Test<Class<U>> test, boolean recursive) throws IOException {
-    Set<Class<U>> matches = new HashSet<>();
-
-    // Loop over the files
-    Queue<File> files = new LinkedList<>(safeListFiles(dir, null));
-    while (!files.isEmpty()) {
-      File file = files.poll();
-      if (file.isDirectory() && recursive) {
-        files.addAll(safeListFiles(file, null));
-      } else if (file.isFile()) {
-        // This file matches, test it
-        Testable<Class<U>> testable = test.prepare(file);
-        if (testable != null && testable.passes()) {
-          matches.add(testable.result());
-        }
-      }
-    }
-
-    return matches;
-  }
-
-  private Collection<Class<U>> loadFromJar(File f, Test<Class<U>> test, boolean recursive, Iterable<String> locators,
-                                           boolean embeddable)
-      throws IOException {
-    Set<Class<U>> matches = new HashSet<>();
-
-    JarFile jarFile;
-    try {
-      jarFile = new JarFile(f);
-    } catch (IOException e) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("Error opening JAR file [" + f.getAbsolutePath() + "]", e);
-      } else {
-        logger.warn("Error opening JAR file [" + f.getAbsolutePath() + "]");
-      }
-      return Collections.emptyList();
-    }
-
-    Enumeration<JarEntry> en = jarFile.entries();
-    while (en.hasMoreElements()) {
-      JarEntry entry = en.nextElement();
-      String name = entry.getName();
-
-      // Verify against the locators
-      for (String locator : locators) {
-        int index = name.indexOf(locator + "/");
-        boolean match = (!embeddable && index == 0) || (embeddable && index >= 0);
-        if (!match) {
-          continue;
-        }
-
-        match = recursive || name.indexOf('/', index + locator.length() + 1) == -1;
-        if (!match) {
-          continue;
-        }
-
-        Testable<Class<U>> testable = test.prepare(f, jarFile, entry);
-        if (testable != null && testable.passes()) {
-          matches.add(testable.result());
-          break;
-        }
-      }
-    }
-
-    jarFile.close();
-
-    return matches;
-  }
-
-  /**
-   * This provides a safe mechanism for listing all of the files in a directory. The listFiles method can return null
-   * and cause major issues. This performs that method in a null safe manner.
-   *
-   * @param dir    The directory to list the files for.
-   * @param filter An optional FileFilter.
-   * @return A List of Files, which is never null.
-   */
-  private List<File> safeListFiles(File dir, FileFilter filter) {
-    File[] files = dir.listFiles(filter);
-
-    if (files == null) {
-      return Collections.emptyList();
-    }
-
-    return asList(files);
-  }
-
-  /**
-   * This is the testing interface that produces a testable object, given a file or JAR entry.
-   */
-  public interface Test<T> {
-    Testable<T> prepare(File file) throws IOException;
-
-    Testable<T> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException;
-  }
-
-  /**
-   * This is the testing interface that is used to accept or reject resources.
-   */
-  public interface Testable<T> {
-    /**
-     * @return True if the testable passes, false if it doesn't.
-     */
-    boolean passes();
+    private final Logger logger = LoggerFactory.getLogger(ClassClasspathResolver.class);
 
     /**
-     * @return The test result.
+     * Attempts to load the given file into a ClassReader.
+     *
+     * @param file The file to load.
+     * @return The ClassReader and never null.
+     * @throws IOException If the file doesn't point to a valid class.
      */
-    T result();
-  }
-
-  /**
-   * A Test that checks to see if each class is annotated with any of a number of annotations. If it is, then the test
-   * returns true, otherwise false.
-   */
-  public static class AnnotatedWith<T extends Annotation, U> implements Test<Class<U>> {
-    private final Class<T> annotation;
-
-    public AnnotatedWith(Class<T> annotation) {
-      this.annotation = annotation;
-    }
-
-    public Testable<Class<U>> prepare(File file) throws IOException {
-      if (!file.getName().endsWith(".class")) {
-        return null;
-      }
-      return new AnnotatedWithTestable<>(annotation, load(file));
-    }
-
-    public Testable<Class<U>> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
-      if (!jarEntry.getName().endsWith(".class")) {
-        return null;
-      }
-      return new AnnotatedWithTestable<>(annotation, load(jar, jarFile, jarEntry));
-    }
-
-    private static class AnnotatedWithTestable<T extends Annotation, U> implements Testable<Class<U>> {
-      private final ClassReader classReader;
-
-      private final AnnotatedWithClassVisitor<T> visitor;
-
-      public AnnotatedWithTestable(Class<T> annotation, ClassReader classReader) {
-        this.visitor = new AnnotatedWithClassVisitor<>(annotation);
-        this.classReader = classReader;
-      }
-
-      public boolean passes() {
-        classReader.accept(visitor, ClassReader.SKIP_CODE);
-        return visitor.isPasses();
-      }
-
-      @SuppressWarnings("unchecked")
-      public Class<U> result() {
+    public static ClassReader load(File file) throws IOException {
         try {
-          return (Class<U>) Thread.currentThread().getContextClassLoader().loadClass(classReader.getClassName().replace('/', '.'));
-        } catch (ClassNotFoundException e) {
-          throw new PrimeException(e);
+            return new ClassReader(new FileInputStream(file));
+        } catch (IOException e) {
+            throw new IOException("Error parsing class file at [" + file.getAbsolutePath() + "]", e);
         }
-      }
+    }
 
-      private static class AnnotatedWithClassVisitor<T extends Annotation> extends ClassVisitor {
+    /**
+     * Attempts to load the JarEntry into a ClassReader.
+     *
+     * @param jar      The JAR file that the entry is in.
+     * @param jarFile  The JAR file used to get the InputStream to the entry.
+     * @param jarEntry The JAR entry to load.
+     * @return The ClassReader and never null.
+     * @throws IOException If the JarEntry doesn't point to a valid class.
+     */
+    public static ClassReader load(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
+        try {
+            return new ClassReader(jarFile.getInputStream(jarEntry));
+        } catch (IOException e) {
+            throw new IOException("Error parsing class file at [" + jar.getAbsolutePath() + "!/" + jarEntry.getName() + "]", e);
+        }
+    }
+
+    /**
+     * Attempts to discover resources that pass the test.
+     * <p/>
+     * Examples:
+     * <p/>
+     * <pre>
+     * locators: foo bar
+     *
+     * JAR file in classpath
+     * ----------------------
+     * com/example/foo/sub/File.class
+     *
+     * Directory in classpath (/opt/classpath)
+     * ----------------------
+     * /opt/classpath/com/example/bar/sub/File2.class
+     *
+     * This will find directories com/example/foo and com/example/bar
+     * </pre>
+     *
+     * @param test      The test implementation to determine matching resources.
+     * @param recursive If true, this will recurse into sub-directories. If false, this will only look in the directories
+     *                  given.
+     * @param locators  A list of directory locators that are used to locate directories to find resources in.
+     * @return The matching set.
+     * @throws IOException If there was any errors while inspecting the classpath.
+     */
+    public Set<Class<U>> findByLocators(Test<Class<U>> test, boolean recursive, String... locators)
+            throws IOException {
+        if (locators == null) {
+            return null;
+        }
+
+        Classpath classpath = Classpath.getCurrentClassPath();
+        List<String> names = classpath.getNames();
+        Set<Class<U>> matches = new HashSet<>();
+        for (String name : names) {
+            File f = new File(name);
+            if (f.isDirectory()) {
+                for (String locator : locators) {
+                    Set<File> directories = findDirectories(f, locator);
+                    for (File dir : directories) {
+                        matches.addAll(loadFromDirectory(dir, test, recursive));
+                    }
+                }
+            } else if (f.isFile()) {
+                matches.addAll(loadFromJar(f, test, recursive, asList(locators), true));
+            }
+        }
+
+        return matches;
+    }
+
+    private Set<File> findDirectories(File dir, String locator) {
+        // Loop over the files using tail-recursion
+        Set<File> directories = new HashSet<>();
+        Queue<File> files = new LinkedList<>(safeListFiles(dir, File::isDirectory));
+        while (!files.isEmpty()) {
+            File file = files.poll();
+            if (file.isDirectory() && file.getName().equals(locator)) {
+                directories.add(file);
+            } else if (file.isDirectory()) {
+                files.addAll(safeListFiles(file, null));
+            }
+        }
+
+        return directories;
+    }
+
+    private Collection<Class<U>> loadFromDirectory(File dir, Test<Class<U>> test, boolean recursive) throws IOException {
+        Set<Class<U>> matches = new HashSet<>();
+
+        // Loop over the files
+        Queue<File> files = new LinkedList<>(safeListFiles(dir, null));
+        while (!files.isEmpty()) {
+            File file = files.poll();
+            if (file.isDirectory() && recursive) {
+                files.addAll(safeListFiles(file, null));
+            } else if (file.isFile()) {
+                // This file matches, test it
+                Testable<Class<U>> testable = test.prepare(file);
+                if (testable != null && testable.passes()) {
+                    matches.add(testable.result());
+                }
+            }
+        }
+
+        return matches;
+    }
+
+    private Collection<Class<U>> loadFromJar(File f, Test<Class<U>> test, boolean recursive, Iterable<String> locators,
+                                             boolean embeddable)
+            throws IOException {
+        Set<Class<U>> matches = new HashSet<>();
+
+        JarFile jarFile;
+        try {
+            jarFile = new JarFile(f);
+        } catch (IOException e) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Error opening JAR file [" + f.getAbsolutePath() + "]", e);
+            } else {
+                logger.warn("Error opening JAR file [" + f.getAbsolutePath() + "]");
+            }
+            return Collections.emptyList();
+        }
+
+        Enumeration<JarEntry> en = jarFile.entries();
+        while (en.hasMoreElements()) {
+            JarEntry entry = en.nextElement();
+            String name = entry.getName();
+
+            // Verify against the locators
+            for (String locator : locators) {
+                int index = name.indexOf(locator + "/");
+                boolean match = (!embeddable && index == 0) || (embeddable && index >= 0);
+                if (!match) {
+                    continue;
+                }
+
+                match = recursive || name.indexOf('/', index + locator.length() + 1) == -1;
+                if (!match) {
+                    continue;
+                }
+
+                Testable<Class<U>> testable = test.prepare(f, jarFile, entry);
+                if (testable != null && testable.passes()) {
+                    matches.add(testable.result());
+                    break;
+                }
+            }
+        }
+
+        jarFile.close();
+
+        return matches;
+    }
+
+    /**
+     * This provides a safe mechanism for listing all of the files in a directory. The listFiles method can return null
+     * and cause major issues. This performs that method in a null safe manner.
+     *
+     * @param dir    The directory to list the files for.
+     * @param filter An optional FileFilter.
+     * @return A List of Files, which is never null.
+     */
+    private List<File> safeListFiles(File dir, FileFilter filter) {
+        File[] files = dir.listFiles(filter);
+
+        if (files == null) {
+            return Collections.emptyList();
+        }
+
+        return asList(files);
+    }
+
+    /**
+     * This is the testing interface that produces a testable object, given a file or JAR entry.
+     */
+    public interface Test<T> {
+        Testable<T> prepare(File file) throws IOException;
+
+        Testable<T> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException;
+    }
+
+    /**
+     * This is the testing interface that is used to accept or reject resources.
+     */
+    public interface Testable<T> {
+        /**
+         * @return True if the testable passes, false if it doesn't.
+         */
+        boolean passes();
+
+        /**
+         * @return The test result.
+         */
+        T result();
+    }
+
+    /**
+     * A Test that checks to see if each class is annotated with any of a number of annotations. If it is, then the test
+     * returns true, otherwise false.
+     */
+    public static class AnnotatedWith<T extends Annotation, U> implements Test<Class<U>> {
         private final Class<T> annotation;
 
-        private boolean passes;
-
-        private AnnotatedWithClassVisitor(Class<T> annotation) {
-          super(Opcodes.ASM7);
-          this.annotation = annotation;
+        public AnnotatedWith(Class<T> annotation) {
+            this.annotation = annotation;
         }
 
-        public boolean isPasses() {
-          return passes;
+        public Testable<Class<U>> prepare(File file) throws IOException {
+            if (!file.getName().endsWith(".class")) {
+                return null;
+            }
+            return new AnnotatedWithTestable<>(annotation, load(file));
         }
 
-        @Override
-        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-          desc = desc.replaceAll("^L|;$", "");
-          desc = desc.replace('/', '.');
-
-          passes |= desc.equals(annotation.getName());
-          return null;
+        public Testable<Class<U>> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
+            if (!jarEntry.getName().endsWith(".class")) {
+                return null;
+            }
+            return new AnnotatedWithTestable<>(annotation, load(jar, jarFile, jarEntry));
         }
-      }
-    }
-  }
 
-  /**
-   * A Test that checks to see if each class is assignable to the provided class. Note that this test will match the
-   * parent type itself if it is presented for matching.
-   */
-  public static class IsA<U> implements Test<Class<U>> {
-    private final Class<U> parent;
+        private static class AnnotatedWithTestable<T extends Annotation, U> implements Testable<Class<U>> {
+            private final ClassReader classReader;
 
-    public IsA(Class<U> parent) {
-      this.parent = parent;
-    }
+            private final AnnotatedWithClassVisitor<T> visitor;
 
-    public Testable<Class<U>> prepare(File file) throws IOException {
-      if (!file.getName().endsWith(".class")) {
-        return null;
-      }
-      return new IsATestable<U>(parent, load(file));
-    }
+            public AnnotatedWithTestable(Class<T> annotation, ClassReader classReader) {
+                this.visitor = new AnnotatedWithClassVisitor<>(annotation);
+                this.classReader = classReader;
+            }
 
-    public Testable<Class<U>> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
-      if (!jarEntry.getName().endsWith(".class")) {
-        return null;
-      }
-      return new IsATestable<U>(parent, load(jar, jarFile, jarEntry));
-    }
+            public boolean passes() {
+                classReader.accept(visitor, ClassReader.SKIP_CODE);
+                return visitor.isPasses();
+            }
 
-    private static class IsATestable<U> implements Testable<Class<U>> {
-      private final ClassReader classReader;
+            @SuppressWarnings("unchecked")
+            public Class<U> result() {
+                try {
+                    return (Class<U>) Thread.currentThread().getContextClassLoader().loadClass(classReader.getClassName().replace('/', '.'));
+                } catch (ClassNotFoundException e) {
+                    throw new PrimeException(e);
+                }
+            }
 
-      private final IsAClassVisitor<U> visitor;
+            private static class AnnotatedWithClassVisitor<T extends Annotation> extends ClassVisitor {
+                private final Class<T> annotation;
 
-      public IsATestable(Class<U> parent, ClassReader classReader) {
-        this.visitor = new IsAClassVisitor<>(parent);
-        this.classReader = classReader;
-      }
+                private boolean passes;
 
-      public boolean passes() {
-        classReader.accept(visitor, ClassReader.SKIP_CODE);
-        return visitor.isPasses();
-      }
+                private AnnotatedWithClassVisitor(Class<T> annotation) {
+                    super(Opcodes.ASM9);
+                    this.annotation = annotation;
+                }
 
-      @SuppressWarnings("unchecked")
-      public Class<U> result() {
-        try {
-          return (Class<U>) Thread.currentThread().getContextClassLoader().loadClass(classReader.getClassName().replace('/', '.'));
-        } catch (ClassNotFoundException e) {
-          throw new PrimeException(e);
+                public boolean isPasses() {
+                    return passes;
+                }
+
+                @Override
+                public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                    desc = desc.replaceAll("^L|;$", "");
+                    desc = desc.replace('/', '.');
+
+                    passes |= desc.equals(annotation.getName());
+                    return null;
+                }
+            }
         }
-      }
+    }
 
-      private static class IsAClassVisitor<U> extends ClassVisitor {
+    /**
+     * A Test that checks to see if each class is assignable to the provided class. Note that this test will match the
+     * parent type itself if it is presented for matching.
+     */
+    public static class IsA<U> implements Test<Class<U>> {
         private final Class<U> parent;
 
-        private boolean passes;
-
-        private IsAClassVisitor(Class<U> parent) {
-          super(Opcodes.ASM7);
-          this.parent = parent;
+        public IsA(Class<U> parent) {
+            this.parent = parent;
         }
 
-        public boolean isPasses() {
-          return passes;
+        public Testable<Class<U>> prepare(File file) throws IOException {
+            if (!file.getName().endsWith(".class")) {
+                return null;
+            }
+            return new IsATestable<U>(parent, load(file));
         }
 
-        @Override
-        public void visit(int version, int access, String name, String signature, String superName,
-                          String[] interfaces) {
-          String parentInternalName = parent.getName().replace('.', '/');
-          passes = superName.equals(parentInternalName);
-          if (passes) {
-            return;
-          }
-
-          for (String anInterface : interfaces) {
-            passes = anInterface.equals(parentInternalName);
-            if (passes) {
-              break;
+        public Testable<Class<U>> prepare(File jar, JarFile jarFile, JarEntry jarEntry) throws IOException {
+            if (!jarEntry.getName().endsWith(".class")) {
+                return null;
             }
-          }
-          if (passes) {
-            return;
-          }
-
-          // Walk the inheritance chain
-          ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-          if (!superName.equals("java/lang/Object")) {
-            try {
-              InputStream is = classLoader.getResourceAsStream(superName.replace('.', '/') + ".class");
-              ClassReader reader = new ClassReader(is);
-              reader.accept(this, ClassReader.SKIP_CODE);
-            } catch (IOException e) {
-              // Smother and move on
-            }
-          }
-          if (passes) {
-            return;
-          }
-
-          // Walk the inheritance and implementation chains
-          for (String anInterface : interfaces) {
-            try {
-              InputStream is = classLoader.getResourceAsStream(anInterface.replace('.', '/') + ".class");
-              ClassReader reader = new ClassReader(is);
-              reader.accept(this, ClassReader.SKIP_CODE);
-            } catch (IOException e) {
-              // Smother and move on
-            }
-            if (passes) {
-              return;
-            }
-          }
+            return new IsATestable<U>(parent, load(jar, jarFile, jarEntry));
         }
-      }
+
+        private static class IsATestable<U> implements Testable<Class<U>> {
+            private final ClassReader classReader;
+
+            private final IsAClassVisitor<U> visitor;
+
+            public IsATestable(Class<U> parent, ClassReader classReader) {
+                this.visitor = new IsAClassVisitor<>(parent);
+                this.classReader = classReader;
+            }
+
+            public boolean passes() {
+                classReader.accept(visitor, ClassReader.SKIP_CODE);
+                return visitor.isPasses();
+            }
+
+            @SuppressWarnings("unchecked")
+            public Class<U> result() {
+                try {
+                    return (Class<U>) Thread.currentThread().getContextClassLoader().loadClass(classReader.getClassName().replace('/', '.'));
+                } catch (ClassNotFoundException e) {
+                    throw new PrimeException(e);
+                }
+            }
+
+            private static class IsAClassVisitor<U> extends ClassVisitor {
+                private final Class<U> parent;
+
+                private boolean passes;
+
+                private IsAClassVisitor(Class<U> parent) {
+                    super(Opcodes.ASM9);
+                    this.parent = parent;
+                }
+
+                public boolean isPasses() {
+                    return passes;
+                }
+
+                @Override
+                public void visit(int version, int access, String name, String signature, String superName,
+                                  String[] interfaces) {
+                    String parentInternalName = parent.getName().replace('.', '/');
+                    passes = superName.equals(parentInternalName);
+                    if (passes) {
+                        return;
+                    }
+
+                    for (String anInterface : interfaces) {
+                        passes = anInterface.equals(parentInternalName);
+                        if (passes) {
+                            break;
+                        }
+                    }
+                    if (passes) {
+                        return;
+                    }
+
+                    // Walk the inheritance chain
+                    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+                    if (!superName.equals("java/lang/Object")) {
+                        try {
+                            InputStream is = classLoader.getResourceAsStream(superName.replace('.', '/') + ".class");
+                            ClassReader reader = new ClassReader(is);
+                            reader.accept(this, ClassReader.SKIP_CODE);
+                        } catch (IOException e) {
+                            // Smother and move on
+                        }
+                    }
+                    if (passes) {
+                        return;
+                    }
+
+                    // Walk the inheritance and implementation chains
+                    for (String anInterface : interfaces) {
+                        try {
+                            InputStream is = classLoader.getResourceAsStream(anInterface.replace('.', '/') + ".class");
+                            ClassReader reader = new ClassReader(is);
+                            reader.accept(this, ClassReader.SKIP_CODE);
+                        } catch (IOException e) {
+                            // Smother and move on
+                        }
+                        if (passes) {
+                            return;
+                        }
+                    }
+                }
+            }
+        }
     }
-  }
 }

--- a/src/test/java/org/primeframework/mvc/util/ClassClasspathResolverTest.java
+++ b/src/test/java/org/primeframework/mvc/util/ClassClasspathResolverTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026, Inversoft Inc., All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+package org.primeframework.mvc.util;
+
+import org.primeframework.mvc.util.ClassClasspathResolver.AnnotatedWith;
+import org.primeframework.mvc.util.ClassClasspathResolver.IsA;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Set;
+
+import static org.testng.Assert.assertEquals;
+
+public class ClassClasspathResolverTest {
+    @Test
+    public void findByLocators_annotated_matches_leaf_package_recursive_on() throws IOException {
+        // Use case: A class with the desired annotation exists and is in the right package, we should see it in the results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                true,
+                // util is the leaf package, so should match whether recursive is on or off
+                "util");
+
+        // assert
+        assertEquals(results,
+                Set.of(Matching.class));
+    }
+
+    @Test
+    public void findByLocators_annotated_matches_leaf_package_recursive_off() throws IOException {
+        // Use case: A class with the desired annotation exists and is in the right package, we should see it in the results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                false,
+                // util is the leaf package, so should match whether recursive is on or off
+                "util");
+
+        // assert
+        assertEquals(results,
+                Set.of(Matching.class));
+    }
+
+    @Test
+    public void findByLocators_annotated_matches_recursive_intermediary_package() throws IOException {
+        // Use case: A class with the desired annotation exists and is in the right package, we should see it in the results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                true,
+                // mvc is an intermediary package, should match
+                "mvc");
+
+        // assert
+        assertEquals(results,
+                Set.of(Matching.class));
+    }
+
+    @Test
+    public void findByLocators_annotated_matches_no_recursive() throws IOException {
+        // Use case: A class with the desired annotation exists and is in an intermediary package, but recursive
+        //           is off, so we should not have any results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                false,
+                "mvc");
+
+        // assert
+        assertEquals(results,
+                Set.of());
+    }
+
+    @Test
+    public void findByLocators_no_class_annotated_no_match() throws IOException {
+        // Use case: A class with the desired annotation exists and is in an intermediary package, but recursive
+        //           is off, so we should not have any results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(NonMatchingAnnotation.class),
+                false,
+                "mvc");
+
+        // assert
+        assertEquals(results,
+                Set.of());
+    }
+
+    @Test
+    public void findByLocators_annotated_wrong_locator_no_match() throws IOException {
+        // Use case: A class with the desired annotation exists but the locator does not match the package it's in
+        //           so we should have empty results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                true,
+                "foobar");
+
+        // assert
+        assertEquals(results,
+                Set.of());
+    }
+
+    @Test
+    public void findByLocators_annotated_no_locator() throws IOException {
+        // Use case: A class with the desired annotation exists, but no locator is provided and without a locator
+        //           we should return no results
+
+        // arrange
+        ClassClasspathResolver<Object> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<? extends Class<?>> results = resolver.findByLocators(new AnnotatedWith<>(MatchingAnnotation.class),
+                true);
+
+        // assert
+        assertEquals(results,
+                Set.of());
+    }
+
+    @Test
+    public void findByLocators_is_a_no_match() throws IOException {
+        // Use case: A class with IsA is provided a class and no matching class exists in the package
+
+        // arrange
+        ClassClasspathResolver<String> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<Class<String>> results = resolver.findByLocators(new IsA<>(String.class),
+                true,
+                "util");
+
+        // assert
+        assertEquals(results,
+                Set.of());
+    }
+
+    @Test
+    public void findByLocators_is_a_exact_match() throws IOException {
+        // Use case: A class with IsA is provided a class. 2 classes that ultimately extend from the supplied class are returned in the results
+
+        // arrange
+        ClassClasspathResolver<Matching> resolver = new ClassClasspathResolver<>();
+
+        // act
+        Set<Class<Matching>> results = resolver.findByLocators(new IsA<>(Matching.class),
+                true,
+                "util");
+
+        // assert
+        assertEquals(results,
+                Set.of(Inherit.class, InheritGrandchild.class));
+    }
+
+    // other matchers
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface MatchingAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE)
+    public @interface NonMatchingAnnotation {
+
+    }
+
+    @MatchingAnnotation
+    public static class Matching {
+    }
+
+    public static class Inherit extends Matching {
+
+    }
+
+    public static class InheritGrandchild extends Inherit {
+
+    }
+}


### PR DESCRIPTION
We have the ASM9 dependency but we are not targeting the ASM9 API in the `ClassClasspathResolver` class.

For the use cases of some applications, like the PMVC code base alone, this is fine, because when they call

```
public Set<Class<U>> findByLocators(Test<Class<U>> test, boolean recursive, String... locators)
```

They pass in a test like `new AnnotatedWith<>(classHere)` which works without this change. However, if you use another test that's included in this repository, like `IsA`, then it does not work (as of Java 21), without upgrading to a new version of the ASM API (only done on the 1 "matcher", `IsA`, here.

The failures without this are (with ASM7):
```
java.lang.UnsupportedOperationException: Records requires ASM8
```

and with ASM8:
```
java.lang.UnsupportedOperationException: PermittedSubclasses requires ASM9
```

https://community.developer.atlassian.com/t/record-requires-asm8-java17/85090 discusses this some.