### PR TITLE
Improve the error message when a variable name is not found in a template

### DIFF
--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -108,7 +108,7 @@ public final class BodyTools {
                                                               "actual");
       // if it's a freshly created file, don't annoy them yet
       if (!freshlyCreatedFile && !unusedVariables.isEmpty()) {
-        throw new IllegalArgumentException("No variable %s found in the [%s] template. If it's acceptable for the value to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
+        throw new IllegalArgumentException("Unused variable(s) %s passed into the [%s] template. If it's acceptable for the value to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
                                                                                                                                                                                             .sorted()
                                                                                                                                                                                             .toList(),
                                                                                                                                                                              path));

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -108,7 +108,7 @@ public final class BodyTools {
                                                               "actual");
       // if it's a freshly created file, don't annoy them yet
       if (!freshlyCreatedFile && !unusedVariables.isEmpty()) {
-        throw new IllegalArgumentException("Unused variable(s) %s passed into the [%s] template. If it's acceptable for the value to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
+        throw new IllegalArgumentException("Unused variables %s passed into the [%s] template. If it's acceptable for the value to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
                                                                                                                                                                                             .sorted()
                                                                                                                                                                                             .toList(),
                                                                                                                                                                              path));

--- a/src/test/java/org/primeframework/mvc/test/BodyTools.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyTools.java
@@ -108,7 +108,7 @@ public final class BodyTools {
                                                               "actual");
       // if it's a freshly created file, don't annoy them yet
       if (!freshlyCreatedFile && !unusedVariables.isEmpty()) {
-        throw new IllegalArgumentException("Unused values %s found in the [%s] template. If it's acceptable for the variable to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
+        throw new IllegalArgumentException("No variable %s found in the [%s] template. If it's acceptable for the value to be unused, wrap it in an Optional".formatted(unusedVariables.stream()
                                                                                                                                                                                             .sorted()
                                                                                                                                                                                             .toList(),
                                                                                                                                                                              path));

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -125,7 +125,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "Unused values [othervariable] found in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the variable to be unused, wrap it in an Optional",
+      assertEquals(e.getMessage(), "No variable [othervariable] found in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the value to be unused, wrap it in an Optional",
                    "othervariable is in the map but is not used");
     }
   }

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -125,7 +125,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "No variable [othervariable] found in the [src/test/web/templates/echo.ftl] template. If it's acceptable for the value to be unused, wrap it in an Optional",
+      assertEquals(e.getMessage(), "Unused variable(s) [othervariable] passed into the [src/test/web/templates/echo.ftl] template. If it's acceptable for the value to be unused, wrap it in an Optional",
                    "othervariable is in the map but is not used");
     }
   }

--- a/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
+++ b/src/test/java/org/primeframework/mvc/test/BodyToolsTest.java
@@ -125,7 +125,7 @@ public class BodyToolsTest {
     } catch (Exception e) {
       assertEquals(e.getClass(), IllegalArgumentException.class,
                    "Expected this exception type");
-      assertEquals(e.getMessage(), "Unused variable(s) [othervariable] passed into the [src/test/web/templates/echo.ftl] template. If it's acceptable for the value to be unused, wrap it in an Optional",
+      assertEquals(e.getMessage(), "Unused variables [othervariable] passed into the [src/test/web/templates/echo.ftl] template. If it's acceptable for the value to be unused, wrap it in an Optional",
                    "othervariable is in the map but is not used");
     }
   }


### PR DESCRIPTION
### Problem
The error message thrown when our template processor encounters an unused value feels confusing. 

Template:
```
${foo}
```
Code:
```
RequestBuilder.withJSONFile(myTemplateFile, 
   "bar",  myObject.bar);
```
Error message:
`Unused values [bar] found in the [myTemplate] template. If it's acceptable for the variable to be unused, wrap it in an Optional`. 

To me this sounds like the problem is that `myObject.bar` is null, when actually it's that the template does not include a reference to `bar`. 

### Solution
New error message: 
`Unused variables [bar] passed into the [myTemplate] template. If it's acceptable for the value to be unused, wrap it in an Optional`. 



